### PR TITLE
[Fix] auth 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+
+	implementation 'io.rest-assured:rest-assured:5.3.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,17 @@ repositories {
 }
 
 dependencies {
-	// spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// mysql
+	// database
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java:8.0.32'
+	runtimeOnly("com.mysql:mysql-connector-j")
+	testImplementation 'com.h2database:h2'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// webclient
 	implementation 'org.springframework:spring-webflux:6.0.6'
@@ -75,25 +80,13 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// rest assured
+	implementation 'io.rest-assured:rest-assured:5.3.1'
+
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-
-	// validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-	// h2
-	runtimeOnly 'com.h2database:h2'
-
-	// querydsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-
-	implementation 'io.rest-assured:rest-assured:5.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.app.auth.application.service.AuthService;
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.common.response.ApiResponse;
 
 @RestController
@@ -20,8 +20,8 @@ public class LoginController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
-        Token token = authService.login(request.oauthAccessToken());
-        return ApiResponse.success("로그인에 성공하였습니다.", token);
+        TokenDto tokenDto = authService.login(request.oauthAccessToken());
+        return ApiResponse.success("로그인에 성공하였습니다.", tokenDto);
     }
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yapp.buddycon.app.auth.application.service.LoginRequest;
 import yapp.buddycon.app.auth.application.service.AuthService;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.common.response.ApiResponse;

--- a/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/LoginController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.auth.application.service.LoginRequest;
 import yapp.buddycon.app.auth.application.service.AuthService;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.common.response.ApiResponse;
@@ -20,7 +21,7 @@ public class LoginController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
-        TokenDto tokenDto = authService.login(request.oauthAccessToken());
+        TokenDto tokenDto = authService.login(request);
         return ApiResponse.success("로그인에 성공하였습니다.", tokenDto);
     }
 

--- a/src/main/java/yapp/buddycon/app/auth/adapter/LoginRequest.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/LoginRequest.java
@@ -1,5 +1,6 @@
-package yapp.buddycon.app.auth.application.service;
+package yapp.buddycon.app.auth.adapter;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
@@ -7,7 +8,7 @@ public record LoginRequest(
         String oauthAccessToken,
         @NotBlank
         String nickname,
-        @NotBlank
+        @Email
         String email,
         String gender,
         String age

--- a/src/main/java/yapp/buddycon/app/auth/adapter/LoginRequest.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/LoginRequest.java
@@ -1,9 +1,0 @@
-package yapp.buddycon.app.auth.adapter;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record LoginRequest(
-        @NotBlank
-        String oauthAccessToken
-) {
-}

--- a/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenCreator.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenCreator.java
@@ -4,7 +4,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.user.domain.User;
 
 import java.time.Instant;
@@ -16,7 +16,7 @@ public class JwtTokenCreator {
 
   private final JwtTokenSecretKey jwtTokenSecretKey;
 
-  public Token createToken(User user, Instant accessTokenExpiresIn, Instant refreshTokenExpiresIn, Instant now) {
+  public TokenDto createToken(User user, Instant accessTokenExpiresIn, Instant refreshTokenExpiresIn, Instant now) {
     var key = jwtTokenSecretKey.getSecretKey();
 
     var accessToken = Jwts.builder()
@@ -30,6 +30,6 @@ public class JwtTokenCreator {
       .signWith(key, SignatureAlgorithm.HS512)
       .compact();
 
-    return new Token(accessToken, refreshToken);
+    return new TokenDto(accessToken, refreshToken);
   }
 }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import yapp.buddycon.app.auth.adapter.redis.RedisRefreshTokenStorage;
 import yapp.buddycon.app.auth.application.service.LocalTime;
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 import yapp.buddycon.app.user.domain.User;
 
@@ -25,16 +25,16 @@ public class JwtTokenProvider implements TokenProvider {
   private final JwtTokenCreator jwtTokenCreator;
   private final LocalTime time;
 
-  public Token provide(User user) {
+  public TokenDto provide(User user) {
     Instant now = time.getNow();
     Instant accessTokenExpiresIn = now.plus(Duration.ofMillis(ACCESS_TOKEN_EXPIRE_TIME));
     Instant refreshTokenExpiresIn = now.plus(Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
 
-    Token token = jwtTokenCreator.createToken(user, accessTokenExpiresIn, refreshTokenExpiresIn, now);
+    TokenDto tokenDto = jwtTokenCreator.createToken(user, accessTokenExpiresIn, refreshTokenExpiresIn, now);
 
-    refreshTokenStorage.save(String.valueOf(user.id()), token.refreshToken(), REFRESH_TOKEN_EXPIRE_TIME);
+    refreshTokenStorage.save(String.valueOf(user.id()), tokenDto.refreshToken(), REFRESH_TOKEN_EXPIRE_TIME);
 
-    return token;
+    return tokenDto;
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/oauth/OAuthRequestException.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/oauth/OAuthRequestException.java
@@ -1,8 +1,8 @@
 package yapp.buddycon.app.auth.adapter.oauth;
 
-import yapp.buddycon.app.common.response.ApplicationException;
+import yapp.buddycon.app.common.response.BadRequestException;
 
-public class OAuthRequestException extends ApplicationException {
+public class OAuthRequestException extends BadRequestException {
 
     public OAuthRequestException(String message) {
         super(message);

--- a/src/main/java/yapp/buddycon/app/auth/application/port/out/TokenProvider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/out/TokenProvider.java
@@ -1,9 +1,9 @@
 package yapp.buddycon.app.auth.application.port.out;
 
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.user.domain.User;
 
 public interface TokenProvider {
 
-    Token provide(User user);
+    TokenDto provide(User user);
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -3,6 +3,7 @@ package yapp.buddycon.app.auth.application.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.adapter.LoginRequest;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 import yapp.buddycon.app.user.domain.User;
 

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -13,8 +13,8 @@ public class AuthService {
     private final SignUpDecider signUpDecider;
     private final TokenProvider tokenProvider;
     @Transactional
-    public TokenDto login(String oauthAccessToken) {
-        User user = signUpDecider.decide(oauthAccessToken);
+    public TokenDto login(LoginRequest request) {
+        User user = signUpDecider.decide(request);
         return tokenProvider.provide(user);
     }
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -13,7 +13,7 @@ public class AuthService {
     private final SignUpDecider signUpDecider;
     private final TokenProvider tokenProvider;
     @Transactional
-    public Token login(String oauthAccessToken) {
+    public TokenDto login(String oauthAccessToken) {
         User user = signUpDecider.decide(oauthAccessToken);
         return tokenProvider.provide(user);
     }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/LoginRequest.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/LoginRequest.java
@@ -1,0 +1,15 @@
+package yapp.buddycon.app.auth.application.service;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank
+        String oauthAccessToken,
+        @NotBlank
+        String nickname,
+        @NotBlank
+        String email,
+        String gender,
+        String age
+) {
+}

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -15,9 +15,10 @@ public class SignUpDecider {
   private final UserCommandStorage userCommandStorage;
   private final OAuthUserInfoApi oAuthUserInfoApi;
 
-  public User decide(String oauthAccessToken) {
-    OAuthMemberInfo memberInfo = oAuthUserInfoApi.call(oauthAccessToken);
+  public User decide(LoginRequest request) {
+    OAuthMemberInfo memberInfo = oAuthUserInfoApi.call(request.oauthAccessToken());
     Long clientId = memberInfo.id();
-    return userQueryStorage.findByClientId(clientId).orElseGet(() -> userCommandStorage.save(new User(null, clientId)));
+    return userQueryStorage.findByClientId(clientId).orElseGet(()
+            -> userCommandStorage.save(new User(null, clientId, request.nickname(), request.email(), request.gender(), request.age())));
   }
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -2,6 +2,7 @@ package yapp.buddycon.app.auth.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.adapter.LoginRequest;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;

--- a/src/main/java/yapp/buddycon/app/auth/application/service/TokenDto.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/TokenDto.java
@@ -1,6 +1,6 @@
 package yapp.buddycon.app.auth.application.service;
 
-public record Token(
+public record TokenDto(
   String accessToken,
   String refreshToken
 ) {

--- a/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.reactive.result.method.annotation.ResponseEntityExceptionHandler;
 import yapp.buddycon.app.common.response.ApiResponse;
 import yapp.buddycon.app.common.response.ApplicationException;
+import yapp.buddycon.app.common.response.BadRequestException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +17,12 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = {BadRequestException.class})
+    protected ResponseEntity<?> handleBadRequestException(BadRequestException e) {
+        log.error("handleApplicationException throw BadRequestException : {}", e.getMessage());
+        return ApiResponse.badRequest(e.getMessage(), null);
+    }
 
     @ExceptionHandler(value = {ApplicationException.class})
     protected ResponseEntity<?> handleApplicationException(ApplicationException e) {

--- a/src/main/java/yapp/buddycon/app/common/response/BadRequestException.java
+++ b/src/main/java/yapp/buddycon/app/common/response/BadRequestException.java
@@ -1,0 +1,7 @@
+package yapp.buddycon.app.common.response;
+
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.app.user.adapter.jpa;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +17,16 @@ public class UserEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private Long clientId;
+
+    @NotNull
+    private String nickname;
+
+    @NotNull
+    private String email;
+
+    private String gender;
+
+    private String age;
 }

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserMapper.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserMapper.java
@@ -9,14 +9,14 @@ import java.util.Optional;
 public class UserMapper {
 
     public User toUser(UserEntity entity) {
-        return new User(entity.getId(), entity.getClientId());
+        return new User(entity.getId(), entity.getClientId(), entity.getNickname(), entity.getEmail(), entity.getGender(), entity.getAge());
     }
 
     public Optional<User> toUser(Optional<UserEntity> entity) {
-        return entity.map(userEntity -> new User(userEntity.getId(), userEntity.getClientId()));
+        return entity.map(userEntity -> new User(userEntity.getId(), userEntity.getClientId(), userEntity.getNickname(), userEntity.getEmail(), userEntity.getGender(), userEntity.getAge()));
     }
 
     public UserEntity toEntity(User user) {
-        return new UserEntity(user.id(), user.clientId());
+        return new UserEntity(user.id(), user.clientId(), user.nickname(), user.email(), user.gender(), user.age());
     }
 }

--- a/src/main/java/yapp/buddycon/app/user/domain/User.java
+++ b/src/main/java/yapp/buddycon/app/user/domain/User.java
@@ -2,6 +2,11 @@ package yapp.buddycon.app.user.domain;
 
 public record User(
   Long id,
-  Long clientId
+  Long clientId,
+  String nickname,
+  String email,
+  String gender,
+  String age
 ) {
+
 }

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.application.service.AuthService;
+import yapp.buddycon.app.auth.application.service.LoginRequest;
 import yapp.buddycon.app.auth.application.service.SignUpDecider;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 
@@ -19,12 +20,13 @@ class AuthServiceTest {
         // given
         var oauthAccessToken = "oauthAccessToken";
         var authService = new AuthService(signUpDecider, tokenProvider);
+        var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
 
         // when
-        authService.login(oauthAccessToken);
+        authService.login(request);
 
         // then
-        verify(signUpDecider, times(1)).decide(oauthAccessToken);
+        verify(signUpDecider, times(1)).decide(request);
 
     }
 

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.application.service.AuthService;
-import yapp.buddycon.app.auth.application.service.LoginRequest;
+import yapp.buddycon.app.auth.adapter.LoginRequest;
 import yapp.buddycon.app.auth.application.service.SignUpDecider;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
@@ -18,6 +18,8 @@ import java.lang.reflect.Type;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,7 +30,7 @@ class JwtTokenCreatorTest {
 
     // given
     final var jwtTokenCreator = new JwtTokenCreator(jwtTokenSecretKey);
-    final var user = new User(1L, 12345678L);
+    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
     final var testTime = new LocalTime().getNow();
     final var secretKey = "abcdefghijklmnopqrstuvwxyz12345678901234567890abcdefghijklmnopqrstuvwxyz12345678901234567890";
 

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenCreator;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenSecretKey;
 import yapp.buddycon.app.auth.application.service.LocalTime;
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.user.domain.User;
 
 import java.lang.reflect.Type;
@@ -35,16 +35,16 @@ class JwtTokenCreatorTest {
     when(jwtTokenSecretKey.getSecretKey()).thenReturn(Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)));
 
     // when
-    Token token = jwtTokenCreator.createToken(user, testTime, testTime, testTime);
+    TokenDto tokenDto = jwtTokenCreator.createToken(user, testTime, testTime, testTime);
 
     // then
-    Map<String, String> map = makePayloadToJson(token);
+    Map<String, String> map = makePayloadToJson(tokenDto);
     assertEquals(user.id().toString(), map.get("id"));
   }
 
-  private static Map<String, String> makePayloadToJson(Token token) {
+  private static Map<String, String> makePayloadToJson(TokenDto tokenDto) {
     Base64.Decoder decoder = Base64.getUrlDecoder();
-    String payload = new String(decoder.decode(token.accessToken().split("\\.")[1]));
+    String payload = new String(decoder.decode(tokenDto.accessToken().split("\\.")[1]));
     final Type mapType = new TypeToken<Map<String, String>>(){}.getType();
     Map<String, String> map = new Gson().fromJson(payload, mapType);
     return map;

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
@@ -9,7 +9,7 @@ import yapp.buddycon.app.auth.adapter.jwt.JwtTokenCreator;
 import yapp.buddycon.app.auth.adapter.redis.RedisRefreshTokenStorage;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenProvider;
 import yapp.buddycon.app.auth.application.service.LocalTime;
-import yapp.buddycon.app.auth.application.service.Token;
+import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.user.domain.User;
 
 import static org.mockito.Mockito.*;
@@ -32,7 +32,7 @@ class JwtTokenProviderTest {
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);
-    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new Token("access", "refresh"));
+    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
 
     // when
     jwtTokenProvider.provide(user);
@@ -48,7 +48,7 @@ class JwtTokenProviderTest {
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);
-    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new Token("access", "refresh"));
+    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
 
     // when
     jwtTokenProvider.provide(user);

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
@@ -28,7 +28,8 @@ class JwtTokenProviderTest {
   @Test
   void 토큰을_생성할때_token_creator는_한번_invocation_된다() {
     // given
-    final var user = new User(1L, 12345678L);
+//    final var user = new User(1L, 12345678L);
+    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);
@@ -44,7 +45,7 @@ class JwtTokenProviderTest {
   @Test
   void 토큰을_생성할때_refresh_token을_한번_저장한다() {
     // given
-    final var user = new User(1L, 12345678L);
+    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);

--- a/src/test/java/yapp/buddycon/app/auth/LoginControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/LoginControllerTest.java
@@ -1,98 +1,138 @@
 package yapp.buddycon.app.auth;
 
-import org.junit.jupiter.api.Test;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import yapp.buddycon.BuddyconApplication;
 import yapp.buddycon.app.auth.adapter.oauth.OAuthRequestException;
+import yapp.buddycon.app.auth.application.service.AuthService;
+import yapp.buddycon.app.auth.application.service.LoginRequest;
 import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
 
-import java.util.Objects;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-@ContextConfiguration(classes = BuddyconApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class LoginControllerTest {
 
     @MockBean
     OAuthUserInfoApi oAuthUserInfoApi;
 
-    @Autowired
-    private MockMvc mockMvc;
+    @MockBean
+    AuthService authService;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
 
     @Test
-    void 정상적인_액세스_토큰의_경우_로그인시_200이_반환된다() throws Exception {
+    void 정상적인_액세스_토큰의_경우_로그인시_200이_반환된다() {
 
         // given
         final var validAccessToken = "valid_access_token";
-        final var body = "{\"oauthAccessToken\":\"" + validAccessToken + "\"}";
+        final var request = new LoginRequest(validAccessToken, "nickname", "email", "gender", "age");
 
         when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(new OAuthMemberInfo(1L));
 
-        final var resultActions = mockMvc.perform(
-                MockMvcRequestBuilders
-                        .post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)
-        );
+        // when
+        final var response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/api/v1/auth/login")
+                .then().statusCode(HttpStatus.OK.value())
+                .log().all()
+                .extract();
 
-        resultActions.andExpect(status().isOk());
-
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     @Test
-    void 정상적이지않은_액세스_토큰의_경우_로그인시_예외가_던져진다() throws Exception {
+    void 정상적이지않은_액세스_토큰의_경우_로그인시_예외가_던져진다() {
 
         // given
         final var invalidAccessToken = "invalid_access_token";
-        final var body = "{\"oauthAccessToken\":\"" + invalidAccessToken + "\"}";
+        final var request = new LoginRequest(invalidAccessToken, "nickname", "email", "gender", "age");
 
-        when(oAuthUserInfoApi.call(invalidAccessToken)).thenThrow(new OAuthRequestException("올바르지않은 액세스토큰입니다."));
+        when(authService.login(request)).thenThrow(new OAuthRequestException("올바르지않은 액세스토큰입니다."));
 
-        final var resultActions = mockMvc.perform(
-                MockMvcRequestBuilders
-                        .post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)
-        );
+        // when
+        final var response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/api/v1/auth/login")
+                .then().log().all()
+                .extract();
 
-        resultActions
-                .andExpect(status().is5xxServerError())
-                .andExpect((result) -> assertTrue(Objects.requireNonNull(result.getResolvedException()).getClass().isAssignableFrom(OAuthRequestException.class)))
-                .andReturn();
-
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test
-    void 액세스토큰_값이_blank라면_bad_request를_던진다() throws Exception {
+    void 액세스토큰_값이_blank라면_bad_request를_던진다() {
 
         // given
         final var invalidAccessToken = "";
-        final var body = "{\"accessToken\":\"" + invalidAccessToken + "\"}";
+        final var request = new LoginRequest(invalidAccessToken, "nickname", "email", "gender", "age");
 
-        final var resultActions = mockMvc.perform(
-                MockMvcRequestBuilders
-                        .post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)
-        );
+        // when
+        final var response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/api/v1/auth/login")
+                .then().log().all()
+                .extract();
 
-        resultActions
-                .andExpect(status().isBadRequest());
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
 
+    @Test
+    void 닉네임이_blank라면_bad_request를_던진다() {
+
+        // given
+        final var validAccessToken = "valid_access_token";
+        final var request = new LoginRequest(validAccessToken, "", "email", "gender", "age");
+
+        // when
+        final var response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/api/v1/auth/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 이메일이_blank라면_bad_request를_던진다() {
+
+        // given
+        final var validAccessToken = "valid_access_token";
+        final var request = new LoginRequest(validAccessToken, "nickname", "", "gender", "age");
+
+        // when
+        final var response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/api/v1/auth/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/yapp/buddycon/app/auth/LoginControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/LoginControllerTest.java
@@ -11,11 +11,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import yapp.buddycon.app.auth.adapter.oauth.OAuthRequestException;
 import yapp.buddycon.app.auth.application.service.AuthService;
-import yapp.buddycon.app.auth.application.service.LoginRequest;
+import yapp.buddycon.app.auth.adapter.LoginRequest;
 import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,7 +41,7 @@ class LoginControllerTest {
 
         // given
         final var validAccessToken = "valid_access_token";
-        final var request = new LoginRequest(validAccessToken, "nickname", "email", "gender", "age");
+        final var request = new LoginRequest(validAccessToken, "nickname", "email@buddycon.com", "gender", "age");
 
         when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(new OAuthMemberInfo(1L));
 
@@ -63,7 +63,7 @@ class LoginControllerTest {
 
         // given
         final var invalidAccessToken = "invalid_access_token";
-        final var request = new LoginRequest(invalidAccessToken, "nickname", "email", "gender", "age");
+        final var request = new LoginRequest(invalidAccessToken, "nickname", "email@buddycon.com", "gender", "age");
 
         when(authService.login(request)).thenThrow(new OAuthRequestException("올바르지않은 액세스토큰입니다."));
 
@@ -84,7 +84,7 @@ class LoginControllerTest {
 
         // given
         final var invalidAccessToken = "";
-        final var request = new LoginRequest(invalidAccessToken, "nickname", "email", "gender", "age");
+        final var request = new LoginRequest(invalidAccessToken, "nickname", "email@buddycon.com", "gender", "age");
 
         // when
         final var response = RestAssured.given().log().all()
@@ -103,7 +103,7 @@ class LoginControllerTest {
 
         // given
         final var validAccessToken = "valid_access_token";
-        final var request = new LoginRequest(validAccessToken, "", "email", "gender", "age");
+        final var request = new LoginRequest(validAccessToken, "", "email@buddycon.com", "gender", "age");
 
         // when
         final var response = RestAssured.given().log().all()
@@ -118,11 +118,12 @@ class LoginControllerTest {
     }
 
     @Test
-    void 이메일이_blank라면_bad_request를_던진다() {
+    void 이메일이_형식에_맞지_않다면_bad_request를_던진다() {
 
         // given
         final var validAccessToken = "valid_access_token";
-        final var request = new LoginRequest(validAccessToken, "nickname", "", "gender", "age");
+        final var invalidEmail = "invalidEmail";
+        final var request = new LoginRequest(validAccessToken, "nickname", invalidEmail, "gender", "age");
 
         // when
         final var response = RestAssured.given().log().all()

--- a/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
+import yapp.buddycon.app.auth.application.service.LoginRequest;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
@@ -25,14 +26,15 @@ class SignUpDeciderTest {
     var validAccessToken = "oauthAccessToken";
     var signUp = new SignUpDecider(userQueryStorage, userCommandStorage, oAuthUserInfoApi);
     var memberInfo = new OAuthMemberInfo(1L);
+    var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
     when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
     when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.empty());
 
     // when
-    signUp.decide(validAccessToken);
+    signUp.decide(request);
 
     // then
-    verify(userCommandStorage).save(new User(null, memberInfo.id()));
+    verify(userCommandStorage).save(new User(null, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age()));
   }
 
   @Test
@@ -42,12 +44,13 @@ class SignUpDeciderTest {
     var validAccessToken = "oauthAccessToken";
     var signUp = new SignUpDecider(userQueryStorage, userCommandStorage, oAuthUserInfoApi);
     var memberInfo = new OAuthMemberInfo(1L);
+    var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
     when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
-    when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.of(new User(1L, memberInfo.id())));
+    when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.of(new User(1L, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age())));
 
 
     // when
-    signUp.decide(validAccessToken);
+    signUp.decide(request);
 
     // then
     verifyNoMoreInteractions(userCommandStorage);

--- a/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
-import yapp.buddycon.app.auth.application.service.LoginRequest;
+import yapp.buddycon.app.auth.adapter.LoginRequest;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;


### PR DESCRIPTION
## 변경사항
1. UserEntity에 닉네임, 이메일, 성별, 연령대 필드 추가
2. Token -> TokenDto 네이밍 변경
3. Controller테스트를 MockMvc에서 RestAssured로 변경
   1. BDD스타일의 메소드 체이닝 기법으로 작성이 가능해, 가독성을 향상시킬 수 있었습니다.
   2. MockMvc의 content메소드는 byte[], String만을 매개변수로 받기때문에, request body를 넘겨줄때 String으로 넘겨줘야하는 문제가 있었습니다.    String으로 넘겨주는 경우 만약 비즈니스 로직 상 request 형식이 바뀌면 test의 request string도 바꿔줘야 했습니다. RestAssured을 사용하면서 json data를 객체로서 쉽게 다룰 수 있었습니다.
   3. MockMvc로 request body를 작성할 때 body에 담기는 내용이 많으면 test given절에서 body에 담을 string절을 만드는 데에 많은 줄이 소요되었습니다.   
      ```java
      final var body = """
                    {
                        "oauthAccessToken":"%s",
                        "nickname":"nickname",
                        "email":"email",
                        "gender":"FEMALE",
                        "age":"10-20"
                    }
                """.formatted(invalidAccessToken);
      ```
      예를들어 위와같이 request에 필드가 많으면 given절이 테스트 내에서 차지하는 비중이 커졌습니다.
   4. 입력을 Dto 객체로 만들고, jackson의 `ObjectMapper.writeValueAsString(dto)`를 사용하면 객체를 스트링으로 변환해주기 때문에 입력을 String으로 관리하지않아도 됐지만, 각 메소드마다 테스트의 목적과 상관없는 메소드를 중복적으로 사용하는 것을 피하고자 하였습니다.