### PR TITLE
[Feature] Gifticon 엔티티에 User 추가 및 인증 로직 반영

### DIFF
--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
@@ -19,13 +20,15 @@ public class GifticonController {
   private final GifticonUseCase gifticonUseCase;
 
   @GetMapping("/unavailable")
-  public Slice<GifticonResponseDTO> getUnavailableGifticons(@Valid PagingDTO dto) {
-    return gifticonUseCase.getUnavailableGifticons(dto);
+  public Slice<GifticonResponseDTO> getUnavailableGifticons(
+      OAuthMemberInfo oAuthMemberInfo, @Valid PagingDTO dto) {
+    return gifticonUseCase.getUnavailableGifticons(oAuthMemberInfo, dto);
   }
 
   @GetMapping("/available")
-  public Slice<GifticonResponseDTO> getAvailableGifticons(@Valid SearchAvailableGifticonDTO dto) {
-    return gifticonUseCase.getAvailableGifticons(dto);
+  public Slice<GifticonResponseDTO> getAvailableGifticons(
+      OAuthMemberInfo oAuthMemberInfo, @Valid SearchAvailableGifticonDTO dto) {
+    return gifticonUseCase.getAvailableGifticons(oAuthMemberInfo, dto);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
@@ -6,10 +6,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
+import yapp.buddycon.common.AuthUser;
 import yapp.buddycon.common.request.PagingDTO;
 
 @RestController
@@ -21,14 +21,14 @@ public class GifticonController {
 
   @GetMapping("/unavailable")
   public Slice<GifticonResponseDTO> getUnavailableGifticons(
-      OAuthMemberInfo oAuthMemberInfo, @Valid PagingDTO dto) {
-    return gifticonUseCase.getUnavailableGifticons(oAuthMemberInfo.id(), dto);
+      AuthUser authUser, @Valid PagingDTO dto) {
+    return gifticonUseCase.getUnavailableGifticons(authUser.id(), dto);
   }
 
   @GetMapping("/available")
   public Slice<GifticonResponseDTO> getAvailableGifticons(
-      OAuthMemberInfo oAuthMemberInfo, @Valid SearchAvailableGifticonDTO dto) {
-    return gifticonUseCase.getAvailableGifticons(oAuthMemberInfo.id(), dto);
+      AuthUser authUser, @Valid SearchAvailableGifticonDTO dto) {
+    return gifticonUseCase.getAvailableGifticons(authUser.id(), dto);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
@@ -22,13 +22,13 @@ public class GifticonController {
   @GetMapping("/unavailable")
   public Slice<GifticonResponseDTO> getUnavailableGifticons(
       OAuthMemberInfo oAuthMemberInfo, @Valid PagingDTO dto) {
-    return gifticonUseCase.getUnavailableGifticons(oAuthMemberInfo, dto);
+    return gifticonUseCase.getUnavailableGifticons(oAuthMemberInfo.id(), dto);
   }
 
   @GetMapping("/available")
   public Slice<GifticonResponseDTO> getAvailableGifticons(
       OAuthMemberInfo oAuthMemberInfo, @Valid SearchAvailableGifticonDTO dto) {
-    return gifticonUseCase.getAvailableGifticons(oAuthMemberInfo, dto);
+    return gifticonUseCase.getAvailableGifticons(oAuthMemberInfo.id(), dto);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
@@ -17,17 +17,17 @@ public class JpaGifticonQueryStorage implements GifticonQueryStorage {
 
 
   @Override
-  public Slice<GifticonResponseDTO> findAllUnavailableGifticons(Pageable pageable) {
-    return gifticonJpaRepository.findAllByUsedIsTrue(pageable);
+  public Slice<GifticonResponseDTO> findAllUnavailableGifticons(long userId, Pageable pageable) {
+    return gifticonJpaRepository.findAllByUsedIsTrueAndUserId(userId, pageable);
   }
 
   @Override
   public Slice<GifticonResponseDTO> findAllAvailableGifticons(
-      GifticonStoreCategory gifticonStoreCategory, Pageable pageable) {
+      long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable) {
     if (gifticonStoreCategory == null) {
-      return gifticonJpaRepository.findAllByUsedIsFalse(pageable);
+      return gifticonJpaRepository.findAllByUsedIsFalseAndUserId(userId, pageable);
     } else {
-      return gifticonJpaRepository.findAllByUsedIsFalseAndGifticonStoreCategory(gifticonStoreCategory, pageable);
+      return gifticonJpaRepository.findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(userId, gifticonStoreCategory, pageable);
     }
   }
 

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/entity/GifticonEntity.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/entity/GifticonEntity.java
@@ -1,18 +1,13 @@
 package yapp.buddycon.app.gifticon.adapter.infra.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import yapp.buddycon.app.user.adapter.jpa.UserEntity;
 import yapp.buddycon.common.BaseEntity;
 
 @Getter
@@ -41,9 +36,13 @@ public class GifticonEntity extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private GifticonStoreCategory gifticonStoreCategory;
 
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private UserEntity user;
+
   @Builder
   private GifticonEntity(String barcode, String imageUrl, String name, String memo,
-      LocalDate expireDate, boolean used, GifticonStore gifticonStore) {
+      LocalDate expireDate, boolean used, GifticonStore gifticonStore, UserEntity user) {
     this.barcode = barcode;
     this.imageUrl = imageUrl;
     this.name = name;
@@ -52,6 +51,7 @@ public class GifticonEntity extends BaseEntity {
     this.used = used;
     this.gifticonStore = gifticonStore;
     this.gifticonStoreCategory = gifticonStore.getCategory();
+    this.user = user;
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
@@ -15,25 +15,28 @@ public interface GifticonJpaRepository extends JpaRepository<GifticonEntity, Lon
       (g.id, g.barcode, g.imageUrl, g.name, g.memo, g.expireDate, g.gifticonStore, g.gifticonStoreCategory)
     from GifticonEntity g
     where g.used = true
+    and g.user.id = :userId
   """)
-  Slice<GifticonResponseDTO> findAllByUsedIsTrue(Pageable pageable);
+  Slice<GifticonResponseDTO> findAllByUsedIsTrueAndUserId(long userId, Pageable pageable);
 
   @Query(value = """
     select new yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO
       (g.id, g.barcode, g.imageUrl, g.name, g.memo, g.expireDate, g.gifticonStore, g.gifticonStoreCategory)
     from GifticonEntity g
     where g.used = false
+    and g.user.id = :userId
   """)
-  Slice<GifticonResponseDTO> findAllByUsedIsFalse(Pageable pageable);
+  Slice<GifticonResponseDTO> findAllByUsedIsFalseAndUserId(long userId, Pageable pageable);
 
   @Query(value = """
     select new yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO
       (g.id, g.barcode, g.imageUrl, g.name, g.memo, g.expireDate, g.gifticonStore, g.gifticonStoreCategory)
     from GifticonEntity g
     where g.used = false
+    and g.user.id = :userId
     and g.gifticonStoreCategory = :gifticonStoreCategory
   """)
-  Slice<GifticonResponseDTO> findAllByUsedIsFalseAndGifticonStoreCategory(
-      GifticonStoreCategory gifticonStoreCategory, Pageable pageable);
+  Slice<GifticonResponseDTO> findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(
+      long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
@@ -1,15 +1,14 @@
 package yapp.buddycon.app.gifticon.application.port.in;
 
 import org.springframework.data.domain.Slice;
-import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.common.request.PagingDTO;
 
 public interface GifticonUseCase {
 
-  Slice<GifticonResponseDTO> getUnavailableGifticons(OAuthMemberInfo oAuthMemberInfo, PagingDTO dto);
+  Slice<GifticonResponseDTO> getUnavailableGifticons(Long userId, PagingDTO dto);
 
-  Slice<GifticonResponseDTO> getAvailableGifticons(OAuthMemberInfo oAuthMemberInfo, SearchAvailableGifticonDTO dto);
+  Slice<GifticonResponseDTO> getAvailableGifticons(Long userId, SearchAvailableGifticonDTO dto);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
@@ -1,14 +1,15 @@
 package yapp.buddycon.app.gifticon.application.port.in;
 
 import org.springframework.data.domain.Slice;
+import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.common.request.PagingDTO;
 
 public interface GifticonUseCase {
 
-  Slice<GifticonResponseDTO> getUnavailableGifticons(PagingDTO dto);
+  Slice<GifticonResponseDTO> getUnavailableGifticons(OAuthMemberInfo oAuthMemberInfo, PagingDTO dto);
 
-  Slice<GifticonResponseDTO> getAvailableGifticons(SearchAvailableGifticonDTO dto);
+  Slice<GifticonResponseDTO> getAvailableGifticons(OAuthMemberInfo oAuthMemberInfo, SearchAvailableGifticonDTO dto);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
@@ -7,11 +7,10 @@ import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 
 public interface GifticonQueryStorage {
 
-  Slice<GifticonResponseDTO> findAllUnavailableGifticons(Pageable pageable);
+  Slice<GifticonResponseDTO> findAllUnavailableGifticons(long userId, Pageable pageable);
 
   Slice<GifticonResponseDTO> findAllAvailableGifticons(
-      GifticonStoreCategory gifticonStoreCategory,
-      Pageable pageable
+      long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable
   );
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
@@ -19,14 +18,14 @@ public class GifticonService implements GifticonUseCase {
   private final GifticonQueryStorage gifticonQueryStorage;
 
   @Override
-  public Slice<GifticonResponseDTO> getUnavailableGifticons(OAuthMemberInfo oAuthMemberInfo, PagingDTO dto) {
-    return gifticonQueryStorage.findAllUnavailableGifticons(oAuthMemberInfo.id(), dto.toPageable());
+  public Slice<GifticonResponseDTO> getUnavailableGifticons(Long userId, PagingDTO dto) {
+    return gifticonQueryStorage.findAllUnavailableGifticons(userId, dto.toPageable());
   }
 
   @Override
-  public Slice<GifticonResponseDTO> getAvailableGifticons(OAuthMemberInfo oAuthMemberInfo, SearchAvailableGifticonDTO dto) {
+  public Slice<GifticonResponseDTO> getAvailableGifticons(Long userId, SearchAvailableGifticonDTO dto) {
     return gifticonQueryStorage.findAllAvailableGifticons(
-        oAuthMemberInfo.id(),
+        userId,
         dto.getGifticonStoreCategory(),
         dto.toPageable());
   }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
@@ -18,13 +19,14 @@ public class GifticonService implements GifticonUseCase {
   private final GifticonQueryStorage gifticonQueryStorage;
 
   @Override
-  public Slice<GifticonResponseDTO> getUnavailableGifticons(PagingDTO dto) {
-    return gifticonQueryStorage.findAllUnavailableGifticons(dto.toPageable());
+  public Slice<GifticonResponseDTO> getUnavailableGifticons(OAuthMemberInfo oAuthMemberInfo, PagingDTO dto) {
+    return gifticonQueryStorage.findAllUnavailableGifticons(oAuthMemberInfo.id(), dto.toPageable());
   }
 
   @Override
-  public Slice<GifticonResponseDTO> getAvailableGifticons(SearchAvailableGifticonDTO dto) {
+  public Slice<GifticonResponseDTO> getAvailableGifticons(OAuthMemberInfo oAuthMemberInfo, SearchAvailableGifticonDTO dto) {
     return gifticonQueryStorage.findAllAvailableGifticons(
+        oAuthMemberInfo.id(),
         dto.getGifticonStoreCategory(),
         dto.toPageable());
   }

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
@@ -5,16 +5,18 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import yapp.buddycon.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "user")
-public class UserEntity {
+public class UserEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @NotNull

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerTest.java
@@ -48,7 +48,7 @@ public class GifticonControllerTest {
     @Test
     void 정상_조회() throws Exception {
       // given
-      when(gifticonUseCase.getUnavailableGifticons(any())).thenReturn(
+      when(gifticonUseCase.getUnavailableGifticons(any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
           new GifticonResponseDTO(),
           new GifticonResponseDTO()))
@@ -68,7 +68,7 @@ public class GifticonControllerTest {
     @Test
     void 빈_리스트() throws Exception {
       // given
-      when(gifticonUseCase.getUnavailableGifticons(any())).thenReturn(
+      when(gifticonUseCase.getUnavailableGifticons(any(), any())).thenReturn(
           new SliceImpl<>(Collections.emptyList()));
 
       // when

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
@@ -17,6 +17,7 @@ import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonEntity;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStore;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
+import yapp.buddycon.app.user.adapter.jpa.UserEntity;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
@@ -31,18 +32,36 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용한_기프티콘_목록만_반환() {
       // given
-      GifticonEntity 사용하지_않은_기프티콘1 = createGifticonEntity("사용하지 않은 기프티콘 1", false, GifticonStore.STARBUCKS);
-      GifticonEntity 사용하지_않은_기프티콘2 = createGifticonEntity("사용하지 않은 기프티콘 2", false, GifticonStore.STARBUCKS);
-      GifticonEntity 사용하지_않은_기프티콘3 = createGifticonEntity("사용하지 않은 기프티콘 3", false, GifticonStore.STARBUCKS);
-      GifticonEntity 사용한_기프티콘1 = createGifticonEntity("사용한 기프티콘 1", true, GifticonStore.STARBUCKS);
-      GifticonEntity 사용한_기프티콘2 = createGifticonEntity("사용한 기프티콘 2", true, GifticonStore.STARBUCKS);
+      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      GifticonEntity 사용하지_않은_기프티콘1 = createGifticonEntity("사용하지 않은 기프티콘 1", false, GifticonStore.STARBUCKS, user);
+      GifticonEntity 사용하지_않은_기프티콘2 = createGifticonEntity("사용하지 않은 기프티콘 2", false, GifticonStore.STARBUCKS, user);
+      GifticonEntity 사용하지_않은_기프티콘3 = createGifticonEntity("사용하지 않은 기프티콘 3", false, GifticonStore.STARBUCKS, user);
+      GifticonEntity 사용한_기프티콘1 = createGifticonEntity("사용한 기프티콘 1", true, GifticonStore.STARBUCKS, user);
+      GifticonEntity 사용한_기프티콘2 = createGifticonEntity("사용한 기프티콘 2", true, GifticonStore.STARBUCKS, user);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository
-          .findAllByUsedIsTrue(PageRequest.of(0, 10));
+          .findAllByUsedIsTrueAndUserId(1l, PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(2);
+      assertThat(result.getContent().get(0).getName()).isEqualTo(사용한_기프티콘1.getName());
+    }
+
+    @Test
+    void 유저_필터링() {
+      UserEntity user = new UserEntity(1l, 111l, "nickname1", "dd1@domain.com", "male", "20");
+      GifticonEntity 사용한_기프티콘1 = createGifticonEntity("사용한 기프티콘 1", true, GifticonStore.STARBUCKS, user);
+
+      UserEntity user2 = new UserEntity(2l, 222l, "nickname2", "dd2@domain.com", "male", "20");
+      GifticonEntity 사용한_기프티콘2 = createGifticonEntity("사용한 기프티콘 2", true, GifticonStore.STARBUCKS, user2);
+
+      // when
+      Slice<GifticonResponseDTO> result = gifticonJpaRepository
+          .findAllByUsedIsTrueAndUserId(1l, PageRequest.of(0, 10));
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
       assertThat(result.getContent().get(0).getName()).isEqualTo(사용한_기프티콘1.getName());
     }
   }
@@ -53,13 +72,14 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용_이전의_기프티콘_목록_조회() {
       // given
-      createGifticonEntity("name1", false, GifticonStore.STARBUCKS);
-      createGifticonEntity("name2", false, GifticonStore.CU);
-      createGifticonEntity("name3", true, GifticonStore.CU);
+      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
+      createGifticonEntity("name2", false, GifticonStore.CU, user);
+      createGifticonEntity("name3", true, GifticonStore.CU, user);
 
       // when
-      Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalse(
-          PageRequest.of(0, 10));
+      Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalseAndUserId(
+          1l, PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(2);
@@ -68,13 +88,14 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 이름_순서로_정렬_목록_조회() {
       // given
-      createGifticonEntity("name5", false, GifticonStore.STARBUCKS);
-      GifticonEntity 조회대상_기프티콘 = createGifticonEntity("name1", false, GifticonStore.CU);
-      createGifticonEntity("name4", false, GifticonStore.MACDONALD);
+      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user);
+      GifticonEntity 조회대상_기프티콘 = createGifticonEntity("name1", false, GifticonStore.CU, user);
+      createGifticonEntity("name4", false, GifticonStore.MACDONALD, user);
 
       // when
-      Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalse(
-          PageRequest.of(0, 10, SearchGifticonSortType.NAME.getSort()));
+      Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalseAndUserId(
+          1l, PageRequest.of(0, 10, SearchGifticonSortType.NAME.getSort()));
 
       // then
       assertThat(result.getContent()).hasSize(3);
@@ -88,12 +109,13 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 카테고리_필터링_지정_목록_조회() {
       // given
-      createGifticonEntity("name1", false, GifticonStore.STARBUCKS);
-      createGifticonEntity("name2", false, GifticonStore.CU);
+      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
+      createGifticonEntity("name2", false, GifticonStore.CU, user);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository
-          .findAllByUsedIsFalseAndGifticonStoreCategory(GifticonStoreCategory.CAFE, PageRequest.of(0, 10));
+          .findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(1l, GifticonStoreCategory.CAFE, PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(1);
@@ -101,7 +123,7 @@ public class GifticonJpaRepositoryTest {
   }
 
   // TODO Entity 메소드로 분리 예정
-  private GifticonEntity createGifticonEntity(String name, boolean used, GifticonStore gifticonStore) {
+  private GifticonEntity createGifticonEntity(String name, boolean used, GifticonStore gifticonStore, UserEntity userEntity) {
     GifticonEntity gifticonEntity = GifticonEntity.builder()
         .barcode("aaaa")
         .imageUrl("url1")
@@ -109,6 +131,7 @@ public class GifticonJpaRepositoryTest {
         .expireDate(LocalDate.now())
         .used(used)
         .gifticonStore(gifticonStore)
+        .user(userEntity)
         .build();
     return gifticonJpaRepository.save(gifticonEntity);
   }

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
@@ -2,6 +2,7 @@ package yapp.buddycon.app.gifticon;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Nested;
@@ -14,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
@@ -34,15 +36,16 @@ public class GifticonServiceTest {
     @Test
     void 정상조회() {
       // given
+      OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo(1l);
       PagingDTO requestDTO = new PagingDTO();
-      when(gifticonQueryStoragePort.findAllUnavailableGifticons(any())).thenReturn(
+      when(gifticonQueryStoragePort.findAllUnavailableGifticons(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
               new GifticonResponseDTO(),
               new GifticonResponseDTO()))
       );
 
       // when
-      Slice<GifticonResponseDTO> resultList = gifticonService.getUnavailableGifticons(requestDTO);
+      Slice<GifticonResponseDTO> resultList = gifticonService.getUnavailableGifticons(oAuthMemberInfo, requestDTO);
 
       // then
       assertThat(resultList.getSize()).isEqualTo(2);
@@ -55,15 +58,16 @@ public class GifticonServiceTest {
     @Test
     void 정상조회() {
       // given
+      OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo(1l);
       SearchAvailableGifticonDTO requestDTO = new SearchAvailableGifticonDTO();
-      when(gifticonQueryStoragePort.findAllAvailableGifticons(any(), any())).thenReturn(
+      when(gifticonQueryStoragePort.findAllAvailableGifticons(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
               new GifticonResponseDTO(),
               new GifticonResponseDTO()))
       );
 
       // when
-      Slice<GifticonResponseDTO> resultList = gifticonService.getAvailableGifticons(requestDTO);
+      Slice<GifticonResponseDTO> resultList = gifticonService.getAvailableGifticons(oAuthMemberInfo, requestDTO);
 
       // then
       assertThat(resultList.getSize()).isEqualTo(2);

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
@@ -36,7 +35,6 @@ public class GifticonServiceTest {
     @Test
     void 정상조회() {
       // given
-      OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo(1l);
       PagingDTO requestDTO = new PagingDTO();
       when(gifticonQueryStoragePort.findAllUnavailableGifticons(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
@@ -45,7 +43,7 @@ public class GifticonServiceTest {
       );
 
       // when
-      Slice<GifticonResponseDTO> resultList = gifticonService.getUnavailableGifticons(oAuthMemberInfo, requestDTO);
+      Slice<GifticonResponseDTO> resultList = gifticonService.getUnavailableGifticons(1l, requestDTO);
 
       // then
       assertThat(resultList.getSize()).isEqualTo(2);
@@ -58,7 +56,6 @@ public class GifticonServiceTest {
     @Test
     void 정상조회() {
       // given
-      OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo(1l);
       SearchAvailableGifticonDTO requestDTO = new SearchAvailableGifticonDTO();
       when(gifticonQueryStoragePort.findAllAvailableGifticons(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
@@ -67,7 +64,7 @@ public class GifticonServiceTest {
       );
 
       // when
-      Slice<GifticonResponseDTO> resultList = gifticonService.getAvailableGifticons(oAuthMemberInfo, requestDTO);
+      Slice<GifticonResponseDTO> resultList = gifticonService.getAvailableGifticons(1l, requestDTO);
 
       // then
       assertThat(resultList.getSize()).isEqualTo(2);


### PR DESCRIPTION
## 개요

- Gifticon 엔티티에 User 추가 및 인증 로직 반영

## 작업 내용

- Gifticon 테이블과 User 테이블 1:n 관계 추가
- Gifticon 목록 조회 시 로그인한 User와 관련된 목록만 내려주도록 수정
- 로직 수정 내용 테스트 코드 반영 및 추가

## 메모

close #12 
