### PR TITLE
[Feature] 기프티콘 상세 조회 API

### DIFF
--- a/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityE
 import yapp.buddycon.app.common.response.ApiResponse;
 import yapp.buddycon.app.common.response.ApplicationException;
 import yapp.buddycon.app.common.response.BadRequestException;
-import yapp.buddycon.app.common.response.ForbiddenRequestException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,12 +28,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<?> handleApplicationException(ApplicationException e) {
         log.error("handleApplicationException throw ApplicationException : {}", e.getMessage());
         return ApiResponse.serverError(e.getMessage(), null);
-    }
-
-    @ExceptionHandler(value = ForbiddenRequestException.class)
-    protected ResponseEntity<?> handleForbiddenRequestException(ForbiddenRequestException e) {
-        log.error("handleForbiddenRequestException throw ForbiddenRequestException : {}", e.getMessage());
-        return ApiResponse.forbidden(e.getMessage(), null);
     }
 
     @ExceptionHandler(value = {MethodArgumentNotValidException.class})

--- a/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yapp/buddycon/app/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityE
 import yapp.buddycon.app.common.response.ApiResponse;
 import yapp.buddycon.app.common.response.ApplicationException;
 import yapp.buddycon.app.common.response.BadRequestException;
+import yapp.buddycon.app.common.response.ForbiddenRequestException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +21,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(value = {BadRequestException.class})
     protected ResponseEntity<?> handleBadRequestException(BadRequestException e) {
-        log.error("handleApplicationException throw BadRequestException : {}", e.getMessage());
+        log.error("handleBadRequestException throw BadRequestException : {}", e.getMessage());
         return ApiResponse.badRequest(e.getMessage(), null);
     }
 
@@ -28,6 +29,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<?> handleApplicationException(ApplicationException e) {
         log.error("handleApplicationException throw ApplicationException : {}", e.getMessage());
         return ApiResponse.serverError(e.getMessage(), null);
+    }
+
+    @ExceptionHandler(value = ForbiddenRequestException.class)
+    protected ResponseEntity<?> handleForbiddenRequestException(ForbiddenRequestException e) {
+        log.error("handleForbiddenRequestException throw ForbiddenRequestException : {}", e.getMessage());
+        return ApiResponse.forbidden(e.getMessage(), null);
     }
 
     @ExceptionHandler(value = {MethodArgumentNotValidException.class})

--- a/src/main/java/yapp/buddycon/app/common/response/ApiResponse.java
+++ b/src/main/java/yapp/buddycon/app/common/response/ApiResponse.java
@@ -20,4 +20,9 @@ public class ApiResponse {
     public static ResponseEntity<?> badRequest(String message, Object body) {
         return ResponseEntity.badRequest().body(new ResponseBody(HttpStatus.BAD_REQUEST.value(), message, body));
     }
+
+
+    public static ResponseEntity<?> forbidden(String message, Object body) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseBody(HttpStatus.FORBIDDEN.value(), message, body));
+    }
 }

--- a/src/main/java/yapp/buddycon/app/common/response/ApiResponse.java
+++ b/src/main/java/yapp/buddycon/app/common/response/ApiResponse.java
@@ -3,8 +3,6 @@ package yapp.buddycon.app.common.response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-
 import static org.springframework.http.HttpStatus.OK;
 
 public class ApiResponse {
@@ -21,8 +19,4 @@ public class ApiResponse {
         return ResponseEntity.badRequest().body(new ResponseBody(HttpStatus.BAD_REQUEST.value(), message, body));
     }
 
-
-    public static ResponseEntity<?> forbidden(String message, Object body) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseBody(HttpStatus.FORBIDDEN.value(), message, body));
-    }
 }

--- a/src/main/java/yapp/buddycon/app/common/response/ForbiddenRequestException.java
+++ b/src/main/java/yapp/buddycon/app/common/response/ForbiddenRequestException.java
@@ -1,7 +1,0 @@
-package yapp.buddycon.app.common.response;
-
-public class ForbiddenRequestException extends RuntimeException{
-  public ForbiddenRequestException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/yapp/buddycon/app/common/response/ForbiddenRequestException.java
+++ b/src/main/java/yapp/buddycon/app/common/response/ForbiddenRequestException.java
@@ -1,0 +1,7 @@
+package yapp.buddycon.app.common.response;
+
+public class ForbiddenRequestException extends RuntimeException{
+  public ForbiddenRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
@@ -1,0 +1,21 @@
+package yapp.buddycon.app.gifticon.adapter;
+
+import yapp.buddycon.app.common.response.BadRequestException;
+
+public class GifticonException extends BadRequestException {
+
+  public enum GifticonExceptionCode {
+    GIFTICON_NOT_FOUND("기프티콘을 찾을 수 없습니다"),
+    ;
+
+    private String message;
+
+    GifticonExceptionCode(String message) {
+      this.message = message;
+    }
+  }
+
+  public GifticonException(GifticonExceptionCode code) {
+    super(code.message);
+  }
+}

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
@@ -1,9 +1,11 @@
 package yapp.buddycon.app.gifticon.adapter;
 
+import lombok.Getter;
 import yapp.buddycon.app.common.response.BadRequestException;
 
 public class GifticonException extends BadRequestException {
 
+  @Getter
   public enum GifticonExceptionCode {
     GIFTICON_NOT_FOUND("기프티콘을 찾을 수 없습니다"),
     ;

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
@@ -3,10 +3,12 @@ package yapp.buddycon.app.gifticon.adapter.client;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.common.response.ApiResponse;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
@@ -33,9 +35,10 @@ public class GifticonController {
   }
 
   @GetMapping("/{gifticon-id}")
-  public GifticonResponseDTO getGifticon(
-      AuthUser authUser, @PathVariable("gifticon-id") long gidticonId) {
-    return gifticonUseCase.getGifticon(authUser.id(), gidticonId);
+  public ResponseEntity<?> getGifticon(
+      AuthUser authUser, @PathVariable("gifticon-id") long gifticonId) {
+    return ApiResponse.success("기프티콘 목록을 성공적으로 조회하였습니다.",
+        gifticonUseCase.getGifticon(authUser.id(), gifticonId));
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/GifticonController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
@@ -29,6 +30,12 @@ public class GifticonController {
   public Slice<GifticonResponseDTO> getAvailableGifticons(
       AuthUser authUser, @Valid SearchAvailableGifticonDTO dto) {
     return gifticonUseCase.getAvailableGifticons(authUser.id(), dto);
+  }
+
+  @GetMapping("/{gifticon-id}")
+  public GifticonResponseDTO getGifticon(
+      AuthUser authUser, @PathVariable("gifticon-id") long gidticonId) {
+    return gifticonUseCase.getGifticon(authUser.id(), gidticonId);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/response/GifticonResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/response/GifticonResponseDTO.java
@@ -1,12 +1,16 @@
 package yapp.buddycon.app.gifticon.adapter.client.response;
 
 import java.time.LocalDate;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStore;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
 
 @Getter
+@Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class GifticonResponseDTO {
 
@@ -30,5 +34,18 @@ public class GifticonResponseDTO {
     this.expireDate = expireDate;
     this.gifticonStore = gifticonStore;
     this.gifticonStoreCategory = gifticonStoreCategory;
+  }
+
+  public static GifticonResponseDTO valueOf(Gifticon gifticon) {
+    GifticonResponseDTO dto = new GifticonResponseDTO();
+    dto.setGifticonId(gifticon.id());
+    dto.setBarcode(gifticon.barcode());
+    dto.setImageUrl(dto.getImageUrl());
+    dto.setName(gifticon.name());
+    dto.setMemo(gifticon.memo());
+    dto.setExpireDate(gifticon.expireDate());
+    dto.setGifticonStore(gifticon.gifticonStore());
+    dto.setGifticonStoreCategory(gifticon.gifticonStoreCategory());
+    return dto;
   }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/response/GifticonResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/response/GifticonResponseDTO.java
@@ -1,51 +1,18 @@
 package yapp.buddycon.app.gifticon.adapter.client.response;
 
 import java.time.LocalDate;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStore;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
-import yapp.buddycon.app.gifticon.domain.Gifticon;
 
-@Getter
-@Setter(AccessLevel.PRIVATE)
-@NoArgsConstructor
-public class GifticonResponseDTO {
+public record GifticonResponseDTO(
+    Long gifticonId,
+    String barcode,
+    String imageUrl,
+    String name,
+    String memo,
+    LocalDate expireDate,
+    GifticonStore gifticonStore,
+    GifticonStoreCategory gifticonStoreCategory
+) {
 
-  private Long gifticonId;
-  private String barcode;
-  private String imageUrl;
-  private String name;
-  private String memo;
-  private LocalDate expireDate;
-  private GifticonStore gifticonStore;
-  private GifticonStoreCategory gifticonStoreCategory;
-
-  public GifticonResponseDTO(Long gifticonId, String barcode, String imageUrl, String name,
-      String memo, LocalDate expireDate, GifticonStore gifticonStore,
-      GifticonStoreCategory gifticonStoreCategory) {
-    this.gifticonId = gifticonId;
-    this.barcode = barcode;
-    this.imageUrl = imageUrl;
-    this.name = name;
-    this.memo = memo;
-    this.expireDate = expireDate;
-    this.gifticonStore = gifticonStore;
-    this.gifticonStoreCategory = gifticonStoreCategory;
-  }
-
-  public static GifticonResponseDTO valueOf(Gifticon gifticon) {
-    GifticonResponseDTO dto = new GifticonResponseDTO();
-    dto.setGifticonId(gifticon.id());
-    dto.setBarcode(gifticon.barcode());
-    dto.setImageUrl(dto.getImageUrl());
-    dto.setName(gifticon.name());
-    dto.setMemo(gifticon.memo());
-    dto.setExpireDate(gifticon.expireDate());
-    dto.setGifticonStore(gifticon.gifticonStore());
-    dto.setGifticonStoreCategory(gifticon.gifticonStoreCategory());
-    return dto;
-  }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
+import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonMapper;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
 import yapp.buddycon.app.gifticon.domain.Gifticon;
 
@@ -17,7 +18,7 @@ import java.util.Optional;
 public class JpaGifticonQueryStorage implements GifticonQueryStorage {
 
   private final GifticonJpaRepository gifticonJpaRepository;
-
+  private final GifticonMapper mapper;
 
   @Override
   public Slice<GifticonResponseDTO> findAllUnavailableGifticons(long userId, Pageable pageable) {
@@ -36,6 +37,7 @@ public class JpaGifticonQueryStorage implements GifticonQueryStorage {
 
   @Override
   public Optional<Gifticon> findByGifticonIdAndUserId(long gifticonId, long userId) {
-    return null;
+    return mapper.toGifticon(gifticonJpaRepository.findByIdAndUserId(gifticonId, userId));
   }
+
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
@@ -9,7 +9,6 @@ import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonMapper;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
-import yapp.buddycon.app.gifticon.domain.Gifticon;
 
 import java.util.Optional;
 
@@ -36,8 +35,8 @@ public class JpaGifticonQueryStorage implements GifticonQueryStorage {
   }
 
   @Override
-  public Optional<Gifticon> findByGifticonIdAndUserId(long gifticonId, long userId) {
-    return mapper.toGifticon(gifticonJpaRepository.findByIdAndUserId(gifticonId, userId));
+  public Optional<GifticonResponseDTO> findByGifticonIdAndUserId(long gifticonId, long userId) {
+    return gifticonJpaRepository.findByIdAndUserId(gifticonId, userId);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
@@ -8,6 +8,9 @@ import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -31,4 +34,8 @@ public class JpaGifticonQueryStorage implements GifticonQueryStorage {
     }
   }
 
+  @Override
+  public Optional<Gifticon> findByGifticonIdAndUserId(long gifticonId, long userId) {
+    return null;
+  }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/JpaGifticonQueryStorage.java
@@ -3,7 +3,7 @@ package yapp.buddycon.app.gifticon.adapter.infra;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
@@ -13,7 +13,7 @@ import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
 import java.util.Optional;
 
 @RequiredArgsConstructor
-@Repository
+@Component
 public class JpaGifticonQueryStorage implements GifticonQueryStorage {
 
   private final GifticonJpaRepository gifticonJpaRepository;

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/entity/GifticonEntity.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/entity/GifticonEntity.java
@@ -37,7 +37,7 @@ public class GifticonEntity extends BaseEntity {
   private GifticonStoreCategory gifticonStoreCategory;
 
   @ManyToOne
-  @JoinColumn(name = "user_id", nullable = false)
+  @JoinColumn(name = "users_id", nullable = false)
   private UserEntity user;
 
   @Builder

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
@@ -41,6 +41,13 @@ public interface GifticonJpaRepository extends JpaRepository<GifticonEntity, Lon
   Slice<GifticonResponseDTO> findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(
       long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable);
 
-  Optional<GifticonEntity> findByIdAndUserId(long gifticonId, long userId);
+  @Query(value = """
+    select new yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO
+      (g.id, g.barcode, g.imageUrl, g.name, g.memo, g.expireDate, g.gifticonStore, g.gifticonStoreCategory)
+    from GifticonEntity g
+    where g.id = :gifticonId
+    and g.user.id = :userId
+  """)
+  Optional<GifticonResponseDTO> findByIdAndUserId(long gifticonId, long userId);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonJpaRepository.java
@@ -8,6 +8,8 @@ import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonEntity;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 
+import java.util.Optional;
+
 public interface GifticonJpaRepository extends JpaRepository<GifticonEntity, Long> {
 
   @Query(value = """
@@ -38,5 +40,7 @@ public interface GifticonJpaRepository extends JpaRepository<GifticonEntity, Lon
   """)
   Slice<GifticonResponseDTO> findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(
       long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable);
+
+  Optional<GifticonEntity> findByIdAndUserId(long gifticonId, long userId);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonMapper.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/infra/jpa/GifticonMapper.java
@@ -1,0 +1,40 @@
+package yapp.buddycon.app.gifticon.adapter.infra.jpa;
+
+import org.springframework.stereotype.Component;
+import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonEntity;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
+import java.util.Optional;
+
+@Component
+public class GifticonMapper {
+
+  public Gifticon toGifticon(GifticonEntity entity) {
+    return Gifticon.builder()
+        .id(entity.getId())
+        .barcode(entity.getBarcode())
+        .imageUrl(entity.getImageUrl())
+        .name(entity.getName())
+        .memo(entity.getMemo())
+        .expireDate(entity.getExpireDate())
+        .used(entity.isUsed())
+        .gifticonStore(entity.getGifticonStore())
+        .gifticonStoreCategory(entity.getGifticonStoreCategory())
+        .build();
+  }
+
+  public Optional<Gifticon> toGifticon(Optional<GifticonEntity> optionalEntity) {
+    return optionalEntity.map(entity ->
+        Gifticon.builder()
+            .id(entity.getId())
+            .barcode(entity.getBarcode())
+            .imageUrl(entity.getImageUrl())
+            .name(entity.getName())
+            .memo(entity.getMemo())
+            .expireDate(entity.getExpireDate())
+            .used(entity.isUsed())
+            .gifticonStore(entity.getGifticonStore())
+            .gifticonStoreCategory(entity.getGifticonStoreCategory())
+            .build());
+  }
+
+}

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/in/GifticonUseCase.java
@@ -11,4 +11,6 @@ public interface GifticonUseCase {
 
   Slice<GifticonResponseDTO> getAvailableGifticons(Long userId, SearchAvailableGifticonDTO dto);
 
+  GifticonResponseDTO getGifticon(Long userId, Long gifticonId);
+
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
@@ -4,6 +4,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
+import java.util.Optional;
 
 public interface GifticonQueryStorage {
 
@@ -12,5 +14,7 @@ public interface GifticonQueryStorage {
   Slice<GifticonResponseDTO> findAllAvailableGifticons(
       long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable
   );
+
+  Optional<Gifticon> findByGifticonIdAndUserId(long gifticonId, long userId);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/out/GifticonQueryStorage.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
-import yapp.buddycon.app.gifticon.domain.Gifticon;
 import java.util.Optional;
 
 public interface GifticonQueryStorage {
@@ -15,6 +14,6 @@ public interface GifticonQueryStorage {
       long userId, GifticonStoreCategory gifticonStoreCategory, Pageable pageable
   );
 
-  Optional<Gifticon> findByGifticonIdAndUserId(long gifticonId, long userId);
+  Optional<GifticonResponseDTO> findByGifticonIdAndUserId(long gifticonId, long userId);
 
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
@@ -29,4 +29,9 @@ public class GifticonService implements GifticonUseCase {
         dto.getGifticonStoreCategory(),
         dto.toPageable());
   }
+
+  @Override
+  public GifticonResponseDTO getGifticon(Long userId, Long gifticonId) {
+    return null;
+  }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.app.gifticon.adapter.GifticonException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
 import yapp.buddycon.common.request.PagingDTO;
 
 @Service
@@ -32,6 +35,8 @@ public class GifticonService implements GifticonUseCase {
 
   @Override
   public GifticonResponseDTO getGifticon(Long userId, Long gifticonId) {
-    return null;
+    Gifticon gifticon = gifticonQueryStorage.findByGifticonIdAndUserId(gifticonId, userId)
+        .orElseThrow(() -> new GifticonException(GifticonExceptionCode.GIFTICON_NOT_FOUND));
+    return GifticonResponseDTO.valueOf(gifticon);
   }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/GifticonService.java
@@ -10,7 +10,6 @@ import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticon
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
-import yapp.buddycon.app.gifticon.domain.Gifticon;
 import yapp.buddycon.common.request.PagingDTO;
 
 @Service
@@ -35,8 +34,7 @@ public class GifticonService implements GifticonUseCase {
 
   @Override
   public GifticonResponseDTO getGifticon(Long userId, Long gifticonId) {
-    Gifticon gifticon = gifticonQueryStorage.findByGifticonIdAndUserId(gifticonId, userId)
+    return gifticonQueryStorage.findByGifticonIdAndUserId(gifticonId, userId)
         .orElseThrow(() -> new GifticonException(GifticonExceptionCode.GIFTICON_NOT_FOUND));
-    return GifticonResponseDTO.valueOf(gifticon);
   }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/domain/Gifticon.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/domain/Gifticon.java
@@ -1,9 +1,11 @@
 package yapp.buddycon.app.gifticon.domain;
 
 import java.time.LocalDate;
+import lombok.Builder;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStore;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 
+@Builder
 public record Gifticon(
     Long id,
     String barcode,

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
@@ -11,12 +11,12 @@ import yapp.buddycon.common.BaseEntity;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user")
+@Table(name = "users")
 public class UserEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "users_id")
     private Long id;
 
     @NotNull

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenDecryptor;
 import yapp.buddycon.app.common.response.BadRequestException;
-import yapp.buddycon.app.common.response.ForbiddenRequestException;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
 import yapp.buddycon.common.AuthUser;
@@ -65,26 +64,6 @@ public class GifticonControllerRestAssuredTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
-        }
-
-        @Test
-        void 요청한_기프티콘의_권한이_없는_사용자가_요청할시_403이_반환된다() {
-            // given
-            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenThrow(new ForbiddenRequestException(""));
-
-            // when
-            Response response = RestAssured
-                .given().log().all()
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                    .header("Authorization", "abc")
-                    .get("/api/v1/gifticons/" + "1");
-
-            // then
-            response
-                .then().log().all()
-                    .statusCode(HttpStatus.FORBIDDEN.value())
-                    .extract();
         }
 
         @Test

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
@@ -49,7 +49,9 @@ public class GifticonControllerRestAssuredTest {
         @Test
         void 요청한_기프티콘의_권한을_가진_사용자가_요청할시_200이_반환된다() {
             // given
-            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenReturn(new GifticonResponseDTO());
+            GifticonResponseDTO gifticonResponseDTO =
+                new GifticonResponseDTO(1L, "", "", "", "", null, null, null);
+            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenReturn(gifticonResponseDTO);
 
             // when
             Response response = RestAssured

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
@@ -13,7 +13,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenDecryptor;
-import yapp.buddycon.app.common.response.BadRequestException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
 import yapp.buddycon.common.AuthUser;
@@ -71,7 +72,8 @@ public class GifticonControllerRestAssuredTest {
         @Test
         void 요청한_기프티콘을_찾을_수_없을시_404가_반환된다() {
             // given
-            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenThrow(new BadRequestException(""));
+            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenThrow(
+                new GifticonException(GifticonExceptionCode.GIFTICON_NOT_FOUND));
 
             // when
             Response response = RestAssured

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
@@ -1,0 +1,110 @@
+package yapp.buddycon.app.gifticon;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import yapp.buddycon.app.auth.adapter.jwt.JwtTokenDecryptor;
+import yapp.buddycon.app.common.response.BadRequestException;
+import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
+import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
+import yapp.buddycon.common.AuthUser;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GifticonControllerRestAssuredTest {
+
+    @MockBean
+    private GifticonUseCase gifticonUseCase;
+
+    @MockBean
+    private JwtTokenDecryptor decryptor;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class getGifticon {
+
+        @BeforeEach
+        void init() {
+            when(decryptor.decrypt(anyString())).thenReturn(new AuthUser(1000L));
+        }
+
+        @Test
+        void 요청한_기프티콘의_권한을_가진_사용자가_요청할시_200이_반환된다() {
+            // given
+            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenReturn(new GifticonResponseDTO());
+
+            // when
+            Response response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .header("Authorization", "abc")
+                .get("/api/v1/gifticons/" + "1");
+
+            // then
+            response
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+        }
+
+        @Test
+        void 요청한_기프티콘의_권한이_없는_사용자가_요청할시_403이_반환된다() {
+            // given
+            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenThrow(new ForbiddenRequestException(""));
+
+            // when
+            Response response = RestAssured
+                .given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                    .header("Authorization", "abc")
+                    .get("/api/v1/gifticons/" + "1");
+
+            // then
+            response
+                .then().log().all()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .extract();
+        }
+
+        @Test
+        void 요청한_기프티콘을_찾을_수_없을시_404가_반환된다() {
+            // given
+            when(gifticonUseCase.getGifticon(anyLong(), anyLong())).thenThrow(new BadRequestException(""));
+
+            // when
+            Response response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .header("Authorization", "abc")
+                .get("/api/v1/gifticons/" + "1");
+
+            // then
+            response
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .extract();
+        }
+    }
+
+}

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerRestAssuredTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenDecryptor;
 import yapp.buddycon.app.common.response.BadRequestException;
+import yapp.buddycon.app.common.response.ForbiddenRequestException;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.in.GifticonUseCase;
 import yapp.buddycon.common.AuthUser;

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonControllerTest.java
@@ -50,8 +50,8 @@ public class GifticonControllerTest {
       // given
       when(gifticonUseCase.getUnavailableGifticons(any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-          new GifticonResponseDTO(),
-          new GifticonResponseDTO()))
+              new GifticonResponseDTO(1L, "", "", "", "", null, null, null),
+              new GifticonResponseDTO(2L, "", "", "", "", null, null, null)))
       );
 
       // when

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
@@ -50,7 +50,7 @@ public class GifticonJpaRepositoryTest {
 
       // then
       assertThat(result.getContent()).hasSize(2);
-      assertThat(result.getContent().get(0).getName()).isEqualTo(사용한_기프티콘1.getName());
+      assertThat(result.getContent().get(0).name()).isEqualTo(사용한_기프티콘1.getName());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GifticonJpaRepositoryTest {
 
       // then
       assertThat(result.getContent()).hasSize(1);
-      assertThat(result.getContent().get(0).getName()).isEqualTo(사용한_기프티콘1.getName());
+      assertThat(result.getContent().get(0).name()).isEqualTo(사용한_기프티콘1.getName());
     }
   }
 
@@ -108,7 +108,7 @@ public class GifticonJpaRepositoryTest {
 
       // then
       assertThat(result.getContent()).hasSize(3);
-      assertThat(result.getContent().get(0).getName()).isEqualTo(조회대상_기프티콘.getName());
+      assertThat(result.getContent().get(0).name()).isEqualTo(조회대상_기프티콘.getName());
     }
   }
 
@@ -143,10 +143,10 @@ public class GifticonJpaRepositoryTest {
       GifticonEntity target = createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
 
       // when
-      Optional<GifticonEntity> result = gifticonJpaRepository.findByIdAndUserId(target.getId(), user.getId());
+      Optional<GifticonResponseDTO> result = gifticonJpaRepository.findByIdAndUserId(target.getId(), user.getId());
 
       // then
-      assertThat(result.get()).isEqualTo(target);
+      assertThat(result.get().gifticonId()).isEqualTo(target.getId());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class GifticonJpaRepositoryTest {
       // given
 
       // when
-      Optional<GifticonEntity> result = gifticonJpaRepository.findByIdAndUserId(1l, 1l);
+      Optional<GifticonResponseDTO> result = gifticonJpaRepository.findByIdAndUserId(1l, 1l);
 
       // then
       assertThat(result).isEqualTo(Optional.empty());

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
@@ -3,6 +3,7 @@ package yapp.buddycon.app.gifticon;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,7 @@ import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonEntity;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStore;
 import yapp.buddycon.app.gifticon.adapter.infra.entity.GifticonStoreCategory;
 import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
+import yapp.buddycon.app.user.adapter.jpa.JpaUserRepository;
 import yapp.buddycon.app.user.adapter.jpa.UserEntity;
 
 @ExtendWith(SpringExtension.class)
@@ -25,6 +27,8 @@ public class GifticonJpaRepositoryTest {
 
   @Autowired
   private GifticonJpaRepository gifticonJpaRepository;
+  @Autowired
+  private JpaUserRepository userRepository;
 
   @Nested
   class findAllByUsedIsTrue {
@@ -32,7 +36,8 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용한_기프티콘_목록만_반환() {
       // given
-      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123l, "nickname", "dd@domain.com", "male", "20");
+      userRepository.save(user);
       GifticonEntity 사용하지_않은_기프티콘1 = createGifticonEntity("사용하지 않은 기프티콘 1", false, GifticonStore.STARBUCKS, user);
       GifticonEntity 사용하지_않은_기프티콘2 = createGifticonEntity("사용하지 않은 기프티콘 2", false, GifticonStore.STARBUCKS, user);
       GifticonEntity 사용하지_않은_기프티콘3 = createGifticonEntity("사용하지 않은 기프티콘 3", false, GifticonStore.STARBUCKS, user);
@@ -41,7 +46,7 @@ public class GifticonJpaRepositoryTest {
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository
-          .findAllByUsedIsTrueAndUserId(1l, PageRequest.of(0, 10));
+          .findAllByUsedIsTrueAndUserId(user.getId(), PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(2);
@@ -50,15 +55,17 @@ public class GifticonJpaRepositoryTest {
 
     @Test
     void 유저_필터링() {
-      UserEntity user = new UserEntity(1l, 111l, "nickname1", "dd1@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 111l, "nickname1", "dd1@domain.com", "male", "20");
+      user = userRepository.save(user);
       GifticonEntity 사용한_기프티콘1 = createGifticonEntity("사용한 기프티콘 1", true, GifticonStore.STARBUCKS, user);
 
-      UserEntity user2 = new UserEntity(2l, 222l, "nickname2", "dd2@domain.com", "male", "20");
+      UserEntity user2 = new UserEntity(null, 222l, "nickname2", "dd2@domain.com", "male", "20");
+      user2 = userRepository.save(user2);
       GifticonEntity 사용한_기프티콘2 = createGifticonEntity("사용한 기프티콘 2", true, GifticonStore.STARBUCKS, user2);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository
-          .findAllByUsedIsTrueAndUserId(1l, PageRequest.of(0, 10));
+          .findAllByUsedIsTrueAndUserId(user.getId(), PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(1);
@@ -72,14 +79,15 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용_이전의_기프티콘_목록_조회() {
       // given
-      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123l, "nickname", "dd@domain.com", "male", "20");
+      user = userRepository.save(user);
       createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
       createGifticonEntity("name2", false, GifticonStore.CU, user);
       createGifticonEntity("name3", true, GifticonStore.CU, user);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalseAndUserId(
-          1l, PageRequest.of(0, 10));
+          user.getId(), PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(2);
@@ -88,14 +96,15 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 이름_순서로_정렬_목록_조회() {
       // given
-      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123l, "nickname", "dd@domain.com", "male", "20");
+      user = userRepository.save(user);
       createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user);
       GifticonEntity 조회대상_기프티콘 = createGifticonEntity("name1", false, GifticonStore.CU, user);
       createGifticonEntity("name4", false, GifticonStore.MACDONALD, user);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository.findAllByUsedIsFalseAndUserId(
-          1l, PageRequest.of(0, 10, SearchGifticonSortType.NAME.getSort()));
+          user.getId(), PageRequest.of(0, 10, SearchGifticonSortType.NAME.getSort()));
 
       // then
       assertThat(result.getContent()).hasSize(3);
@@ -109,16 +118,46 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 카테고리_필터링_지정_목록_조회() {
       // given
-      UserEntity user = new UserEntity(1l, 123l, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123l, "nickname", "dd@domain.com", "male", "20");
+      user = userRepository.save(user);
       createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
       createGifticonEntity("name2", false, GifticonStore.CU, user);
 
       // when
       Slice<GifticonResponseDTO> result = gifticonJpaRepository
-          .findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(1l, GifticonStoreCategory.CAFE, PageRequest.of(0, 10));
+          .findAllByUsedIsFalseAndUserIdAndGifticonStoreCategory(user.getId(), GifticonStoreCategory.CAFE, PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(1);
+    }
+  }
+
+  @Nested
+  class findByGifticonIdAndUserId {
+
+    @Test
+    void 정상조회() {
+      // given
+      UserEntity user = new UserEntity(null, 123l, "nickname", "dd@domain.com", "male", "20");
+      user = userRepository.save(user);
+      GifticonEntity target = createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user);
+
+      // when
+      Optional<GifticonEntity> result = gifticonJpaRepository.findByIdAndUserId(target.getId(), user.getId());
+
+      // then
+      assertThat(result.get()).isEqualTo(target);
+    }
+
+    @Test
+    void 저장된_기프티콘이_없을시_empty반환() {
+      // given
+
+      // when
+      Optional<GifticonEntity> result = gifticonJpaRepository.findByIdAndUserId(1l, 1l);
+
+      // then
+      assertThat(result).isEqualTo(Optional.empty());
     }
   }
 

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
@@ -1,9 +1,10 @@
 package yapp.buddycon.app.gifticon;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,14 +12,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.Arrays;
+import java.util.Optional;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import yapp.buddycon.app.gifticon.adapter.GifticonException;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
 import yapp.buddycon.app.gifticon.application.service.GifticonService;
+import yapp.buddycon.app.gifticon.domain.Gifticon;
 import yapp.buddycon.common.request.PagingDTO;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,4 +74,39 @@ public class GifticonServiceTest {
     }
   }
 
+  @Nested
+  class getGifticon {
+
+    private final Long REQUEST_USER_ID = 1l;
+    private final Long REQUEST_GIFTICON_ID = 1000l;
+
+    @Test
+    void 요청한_기프티콘이_있을_경우_DTO를_반환한다() {
+      // given
+      Gifticon gifticon = new Gifticon(REQUEST_GIFTICON_ID, "", "", "", "", null, false, null, null);
+      when(gifticonQueryStoragePort.findByGifticonIdAndUserId(REQUEST_GIFTICON_ID, REQUEST_USER_ID))
+          .thenReturn(Optional.of(gifticon));
+
+      // when
+      GifticonResponseDTO result = gifticonService.getGifticon(REQUEST_USER_ID, REQUEST_GIFTICON_ID);
+
+      // then
+      assertThat(result.getGifticonId()).isEqualTo(REQUEST_GIFTICON_ID);
+    }
+
+    @Test
+    void 요청한_기프티콘을_찾을_수_없을시_Exception을_던진다() {
+      // given
+      when(gifticonQueryStoragePort.findByGifticonIdAndUserId(REQUEST_GIFTICON_ID, REQUEST_USER_ID))
+          .thenReturn(Optional.empty());
+
+      // when
+      Throwable exception = assertThrows(GifticonException.class, () -> {
+        gifticonService.getGifticon(REQUEST_USER_ID, REQUEST_GIFTICON_ID);
+      });
+
+      // then
+      assertEquals("기프티콘을 찾을 수 없습니다", exception.getMessage());
+    }
+  }
 }

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
@@ -41,8 +41,8 @@ public class GifticonServiceTest {
       PagingDTO requestDTO = new PagingDTO();
       when(gifticonQueryStoragePort.findAllUnavailableGifticons(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new GifticonResponseDTO(),
-              new GifticonResponseDTO()))
+              new GifticonResponseDTO(1L, "", "", "", "", null, null, null),
+              new GifticonResponseDTO(2L, "", "", "", "", null, null, null)))
       );
 
       // when
@@ -62,8 +62,8 @@ public class GifticonServiceTest {
       SearchAvailableGifticonDTO requestDTO = new SearchAvailableGifticonDTO();
       when(gifticonQueryStoragePort.findAllAvailableGifticons(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new GifticonResponseDTO(),
-              new GifticonResponseDTO()))
+              new GifticonResponseDTO(1L, "", "", "", "", null, null, null),
+              new GifticonResponseDTO(2L, "", "", "", "", null, null, null)))
       );
 
       // when
@@ -83,15 +83,15 @@ public class GifticonServiceTest {
     @Test
     void 요청한_기프티콘이_있을_경우_DTO를_반환한다() {
       // given
-      Gifticon gifticon = new Gifticon(REQUEST_GIFTICON_ID, "", "", "", "", null, false, null, null);
+      GifticonResponseDTO gifticonResponseDTO = new GifticonResponseDTO(REQUEST_GIFTICON_ID, "", "", "", "", null, null, null);
       when(gifticonQueryStoragePort.findByGifticonIdAndUserId(REQUEST_GIFTICON_ID, REQUEST_USER_ID))
-          .thenReturn(Optional.of(gifticon));
+          .thenReturn(Optional.of(gifticonResponseDTO));
 
       // when
       GifticonResponseDTO result = gifticonService.getGifticon(REQUEST_USER_ID, REQUEST_GIFTICON_ID);
 
       // then
-      assertThat(result.getGifticonId()).isEqualTo(REQUEST_GIFTICON_ID);
+      assertThat(result.gifticonId()).isEqualTo(REQUEST_GIFTICON_ID);
     }
 
     @Test

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonServiceTest.java
@@ -17,11 +17,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import yapp.buddycon.app.gifticon.adapter.GifticonException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode;
 import yapp.buddycon.app.gifticon.adapter.client.request.SearchAvailableGifticonDTO;
 import yapp.buddycon.app.gifticon.adapter.client.response.GifticonResponseDTO;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonQueryStorage;
 import yapp.buddycon.app.gifticon.application.service.GifticonService;
-import yapp.buddycon.app.gifticon.domain.Gifticon;
 import yapp.buddycon.common.request.PagingDTO;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,7 +106,7 @@ public class GifticonServiceTest {
       });
 
       // then
-      assertEquals("기프티콘을 찾을 수 없습니다", exception.getMessage());
+      assertEquals(GifticonExceptionCode.GIFTICON_NOT_FOUND.getMessage(), exception.getMessage());
     }
   }
 }


### PR DESCRIPTION
## 작업 내용

- 기프티콘 상세 조회(`/api/v1/gifticons/{id}`) API 추가
- user 테이블 명 users로 변경
  - 테스트에서 사용하는 h2 데이터베이스에서 user는 예약어로 사용하고 있기 때문에 오류가 발생하였습니다. 따라서 users로 변경하여 해당 오류를 수정했습니다.

## 메모

이번엔 controller 테스트에 RestAssured를 적용해 봤습니다 ㅎㅎ

한 가지 고민되는 부분은 Gifticon을 조회해 올 때 불필요하게 여러번 변환하는게 아닌가 싶습니다.
현재 구조를 보면 JpaRepository에서 GifticonEntity로 조회하고, Gifticon 으로 파싱 후 GifticonResponseDTO로 한 번 더 변환이 됩니다. 사실 JpaRepository에서 GifticonResponseDTO로 한 번에 조회해 올 수 있는데 말이죠.
비즈니스 로직이 없는 순수 조회 API에서는 목록 조회와 같이 JpaRepository에서 한 번에 ResponseDTO로 불러오는게 좋을까요? 아니면 통일성 있게 현재 구조로 가는게 좋을까요? 고민해 보시고 의견 부탁드립니다!


close #15 