### PR TITLE
[Feature] 알림 목록 조회

### DIFF
--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
@@ -1,0 +1,33 @@
+package yapp.buddycon.app.notification.adapter.client;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.common.AuthUser;
+import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.common.response.ApiResponse;
+import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
+
+@Tag(name = "알림 조회", description = "알림 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class ReadNotificationController {
+
+  private final ReadNotificationUseCase readUseCase;
+
+  @Operation(summary = "알림 목록 조회")
+  @GetMapping
+  public ResponseEntity<?> getNotifications(
+      @Parameter(hidden = true) AuthUser authUser, @Valid PagingDTO dto) {
+    return ApiResponse.successWithBody("알림 목록을 성공적으로 조회하였습니다.",
+        readUseCase.getNotifications(authUser.id(), dto));
+  }
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
@@ -2,9 +2,9 @@ package yapp.buddycon.app.notification.adapter.client.response;
 
 public record NotificationResponseDTO(
     Long notificationId,
-    Long notificationAnnouncementId,
-    String notificationAnnouncementTitle,
-    Long notificationGifticonExpirationAlertId,
+    Long announcementId,
+    String announcementTitle,
+    Long GifticonExpirationAlertId,
     Integer gifticonDaysLeft,
     Long gifticonId,
     String gifticonName

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
@@ -1,0 +1,14 @@
+package yapp.buddycon.app.notification.adapter.client.response;
+
+public record NotificationResponseDTO(
+    Long notificationId,
+    Long notificationAnnouncementId,
+    String notificationAnnouncementTitle,
+    Long notificationGifticonExpirationAlertId,
+    Integer gifticonDaysLeft,
+    Long gifticonId,
+    String gifticonName
+//    boolean checked
+) {
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
@@ -1,16 +1,21 @@
 package yapp.buddycon.app.notification.adapter.infra;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationJpaRepository;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
 
+@RequiredArgsConstructor
 @Component
 public class JpaNotificationQueryStorage implements NotificationQueryStorage {
 
+  private final NotificationJpaRepository notificationJpaRepository;
+
   @Override
-  public Slice<NotificationResponseDTO> findAll(long userId, Pageable pageable) {
-    return null;
+  public Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable) {
+    return notificationJpaRepository.findAllByUserId(userId, pageable);
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
@@ -1,0 +1,16 @@
+package yapp.buddycon.app.notification.adapter.infra;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
+
+@Component
+public class JpaNotificationQueryStorage implements NotificationQueryStorage {
+
+  @Override
+  public Slice<NotificationResponseDTO> findAll(long userId, Pageable pageable) {
+    return null;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiEntity.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiEntity.java
@@ -1,0 +1,35 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yapp.buddycon.app.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "announcement_noti")
+public class AnnouncementNotiEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "announcement_noti_id")
+  private Long id;
+  @Column(name = "notification_id", nullable = false)
+  private Long notificationId;
+  private String title;
+  private String body;
+
+  public AnnouncementNotiEntity(Long id, Long notificationId, String title, String body) {
+    this.id = id;
+    this.notificationId = notificationId;
+    this.title = title;
+    this.body = body;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiJpaRepository.java
@@ -1,0 +1,7 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementNotiJpaRepository extends JpaRepository<AnnouncementNotiEntity, Long> {
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationAlertNotiEntity.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationAlertNotiEntity.java
@@ -14,12 +14,12 @@ import yapp.buddycon.app.common.BaseEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "gifticon_expiration_noti")
-public class GifticonExpirationNotiEntity extends BaseEntity {
+@Table(name = "gifticon_expiration_alert_noti")
+public class GifticonExpirationAlertNotiEntity extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "gifticon_expiration_noti_id")
+  @Column(name = "gifticon_expiration_alert_noti_id")
   private Long id;
   @Column(name = "notification_id", nullable = false)
   private Long notificationId;
@@ -28,7 +28,7 @@ public class GifticonExpirationNotiEntity extends BaseEntity {
   @Column(name = "days_left", nullable = false)
   private Integer daysLeft;
 
-  public GifticonExpirationNotiEntity(Long id, Long notificationId, Long gifticonId,
+  public GifticonExpirationAlertNotiEntity(Long id, Long notificationId, Long gifticonId,
       Integer daysLeft) {
     this.id = id;
     this.notificationId = notificationId;

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiEntity.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiEntity.java
@@ -1,0 +1,38 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yapp.buddycon.app.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "gifticon_expiration_noti")
+public class GifticonExpirationNotiEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "gifticon_expiration_noti_id")
+  private Long id;
+  @Column(name = "notification_id", nullable = false)
+  private Long notificationId;
+  @Column(name = "gifticon_id", nullable = false)
+  private Long gifticonId;
+  @Column(name = "days_left", nullable = false)
+  private Integer daysLeft;
+
+  public GifticonExpirationNotiEntity(Long id, Long notificationId, Long gifticonId,
+      Integer daysLeft) {
+    this.id = id;
+    this.notificationId = notificationId;
+    this.gifticonId = gifticonId;
+    this.daysLeft = daysLeft;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiJpaRepository.java
@@ -1,0 +1,7 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GifticonExpirationNotiJpaRepository extends JpaRepository<GifticonExpirationNotiEntity, Long> {
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/GifticonExpirationNotiJpaRepository.java
@@ -2,6 +2,6 @@ package yapp.buddycon.app.notification.adapter.infra.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GifticonExpirationNotiJpaRepository extends JpaRepository<GifticonExpirationNotiEntity, Long> {
+public interface GifticonExpirationNotiJpaRepository extends JpaRepository<GifticonExpirationAlertNotiEntity, Long> {
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationEntity.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationEntity.java
@@ -1,0 +1,28 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yapp.buddycon.app.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notification")
+public class NotificationEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  public NotificationEntity(Long id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
@@ -1,0 +1,26 @@
+package yapp.buddycon.app.notification.adapter.infra.jpa;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+
+public interface NotificationJpaRepository extends JpaRepository<NotificationEntity, Long> {
+
+  @Query(value = """
+    SELECT new yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO
+      (n.id, an.id, an.title, gen.id, gen.daysLeft, g.id, g.name)
+    FROM NotificationEntity n
+    LEFT OUTER JOIN AnnouncementNotiEntity an
+      ON n.id = an.notificationId
+    LEFT OUTER JOIN GifticonExpirationNotiEntity gen
+      ON n.id = gen.notificationId
+    LEFT OUTER JOIN GifticonEntity g
+      ON gen.gifticonId = g.id
+    WHERE g.userId = :userId
+       OR g.userId IS NULL
+  """)
+  Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable);
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
@@ -14,7 +14,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
     FROM NotificationEntity n
     LEFT OUTER JOIN AnnouncementNotiEntity an
       ON n.id = an.notificationId
-    LEFT OUTER JOIN GifticonExpirationNotiEntity gen
+    LEFT OUTER JOIN GifticonExpirationAlertNotiEntity gen
       ON n.id = gen.notificationId
     LEFT OUTER JOIN GifticonEntity g
       ON gen.gifticonId = g.id

--- a/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
@@ -1,0 +1,11 @@
+package yapp.buddycon.app.notification.application.port.in;
+
+import org.springframework.data.domain.Slice;
+import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+
+public interface ReadNotificationUseCase {
+
+  Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto);
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
@@ -1,0 +1,11 @@
+package yapp.buddycon.app.notification.application.port.out;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+
+public interface NotificationQueryStorage {
+
+  Slice<NotificationResponseDTO> findAll(long userId, Pageable pageable);
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
@@ -6,6 +6,6 @@ import yapp.buddycon.app.notification.adapter.client.response.NotificationRespon
 
 public interface NotificationQueryStorage {
 
-  Slice<NotificationResponseDTO> findAll(long userId, Pageable pageable);
+  Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -1,16 +1,23 @@
 package yapp.buddycon.app.notification.application.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.app.common.request.PagingDTO;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
+import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReadNotificationService implements ReadNotificationUseCase {
+
+  private final NotificationQueryStorage queryStorage;
 
   @Override
   public Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto) {
-    return null;
+    return queryStorage.findAll(userId, dto.toPageable());
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -1,0 +1,16 @@
+package yapp.buddycon.app.notification.application.service;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
+
+@Service
+public class ReadNotificationService implements ReadNotificationUseCase {
+
+  @Override
+  public Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto) {
+    return null;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -18,6 +18,6 @@ public class ReadNotificationService implements ReadNotificationUseCase {
 
   @Override
   public Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto) {
-    return queryStorage.findAll(userId, dto.toPageable());
+    return queryStorage.findAllByUserId(userId, dto.toPageable());
   }
 }

--- a/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
@@ -1,0 +1,99 @@
+package yapp.buddycon.app.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonEntity;
+import yapp.buddycon.app.gifticon.adapter.infra.jpa.GifticonJpaRepository;
+import yapp.buddycon.app.gifticon.domain.GifticonStore;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiJpaRepository;
+import yapp.buddycon.app.notification.adapter.infra.jpa.GifticonExpirationNotiEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.GifticonExpirationNotiJpaRepository;
+import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationJpaRepository;
+import yapp.buddycon.app.user.adapter.jpa.JpaUserRepository;
+import yapp.buddycon.app.user.adapter.jpa.UserEntity;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+public class NotificationJpaRepositoryTest {
+
+  @Autowired
+  private NotificationJpaRepository notificationRepository;
+  @Autowired
+  private GifticonExpirationNotiJpaRepository gifticonExpirationNotiRepository;
+  @Autowired
+  private AnnouncementNotiJpaRepository announcementNotiRepository;
+  @Autowired
+  private JpaUserRepository userRepository;
+  @Autowired
+  private GifticonJpaRepository gifticonJpaRepository;
+
+  @Nested
+  class findAllByUserId {
+
+    @BeforeEach
+    void dataInit() {
+      userRepository.save(new UserEntity(1L, 123L, "nickname1", "aa@domain.com", "male", "20"));
+      userRepository.save(new UserEntity(2L, 456L, "nickname2", "bb@domain.com", "female", "20"));
+    }
+
+    @Test
+    void 기프티콘_만료_알림은_유저아이디를_기준으로_필터링된다() {
+      // given
+      gifticonJpaRepository.save(new GifticonEntity(1L, 1L, "url1", "name1", "memo1", LocalDate.now(), false, GifticonStore.STARBUCKS));
+      gifticonJpaRepository.save(new GifticonEntity(2L, 2L, "url2", "name2", "memo2", LocalDate.now(), false, GifticonStore.MACDONALD));
+
+      notificationRepository.save(new NotificationEntity(1L));
+      notificationRepository.save(new NotificationEntity(2L));
+      notificationRepository.save(new NotificationEntity(3L));
+
+      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(1L, 1L, 1L, 14));
+      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(2L, 2L, 1L, 7));
+      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(3L, 3L, 2L, 7));
+
+      // when
+      Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(1L, PageRequest.of(0, 10));
+
+      // then
+      assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    void 공지사항을_포함한다() {
+      // given
+      notificationRepository.save(new NotificationEntity(1L));
+
+      announcementNotiRepository.save(new AnnouncementNotiEntity(1L, 1L, "title", "body"));
+
+      // when
+      Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(1L, PageRequest.of(0, 10));
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    void 조회된_결과가_없을_시_빈_리스트를_반환한다() {
+      // given
+
+      // when
+      Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(1L, PageRequest.of(0, 10));
+
+      // then
+      assertThat(result.getContent()).hasSize(0);
+    }
+
+  }
+}

--- a/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
@@ -18,7 +18,7 @@ import yapp.buddycon.app.gifticon.domain.GifticonStore;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiEntity;
 import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiJpaRepository;
-import yapp.buddycon.app.notification.adapter.infra.jpa.GifticonExpirationNotiEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.GifticonExpirationAlertNotiEntity;
 import yapp.buddycon.app.notification.adapter.infra.jpa.GifticonExpirationNotiJpaRepository;
 import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationEntity;
 import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationJpaRepository;
@@ -43,28 +43,36 @@ public class NotificationJpaRepositoryTest {
   @Nested
   class findAllByUserId {
 
+    private UserEntity 사용자1;
+    private UserEntity 사용자2;
+
     @BeforeEach
     void dataInit() {
-      userRepository.save(new UserEntity(1L, 123L, "nickname1", "aa@domain.com", "male", "20"));
-      userRepository.save(new UserEntity(2L, 456L, "nickname2", "bb@domain.com", "female", "20"));
+      사용자1 = userRepository.save(new UserEntity(null, 123L, "nickname1", "aa@domain.com", "male", "20"));
+      사용자2 = userRepository.save(new UserEntity(null, 456L, "nickname2", "bb@domain.com", "female", "20"));
     }
 
     @Test
     void 기프티콘_만료_알림은_유저아이디를_기준으로_필터링된다() {
       // given
-      gifticonJpaRepository.save(new GifticonEntity(1L, 1L, "url1", "name1", "memo1", LocalDate.now(), false, GifticonStore.STARBUCKS));
-      gifticonJpaRepository.save(new GifticonEntity(2L, 2L, "url2", "name2", "memo2", LocalDate.now(), false, GifticonStore.MACDONALD));
+      GifticonEntity 사용자1_기프티콘 = gifticonJpaRepository.save(
+          new GifticonEntity(null, 사용자1.getId(), "url1", "name1", "memo1", LocalDate.now(), false, GifticonStore.STARBUCKS));
+      GifticonEntity 사용자2_기프티콘 = gifticonJpaRepository.save(
+          new GifticonEntity(null, 사용자2.getId(), "url2", "name2", "memo2", LocalDate.now(), false, GifticonStore.MACDONALD));
 
-      notificationRepository.save(new NotificationEntity(1L));
-      notificationRepository.save(new NotificationEntity(2L));
-      notificationRepository.save(new NotificationEntity(3L));
+      NotificationEntity 알림1 = notificationRepository.save(new NotificationEntity(null));
+      NotificationEntity 알림2 = notificationRepository.save(new NotificationEntity(null));
+      NotificationEntity 알림3 = notificationRepository.save(new NotificationEntity(null));
 
-      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(1L, 1L, 1L, 14));
-      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(2L, 2L, 1L, 7));
-      gifticonExpirationNotiRepository.save(new GifticonExpirationNotiEntity(3L, 3L, 2L, 7));
+      GifticonExpirationAlertNotiEntity 조회_대상1 = gifticonExpirationNotiRepository.save(
+          new GifticonExpirationAlertNotiEntity(null, 알림1.getId(), 사용자1_기프티콘.getId(), 14));
+      GifticonExpirationAlertNotiEntity 조회_대상2 = gifticonExpirationNotiRepository.save(
+          new GifticonExpirationAlertNotiEntity(null, 알림2.getId(), 사용자1_기프티콘.getId(), 7));
+      GifticonExpirationAlertNotiEntity 필터링_대상 = gifticonExpirationNotiRepository.save(
+          new GifticonExpirationAlertNotiEntity(null, 알림3.getId(), 사용자2_기프티콘.getId(), 7));
 
       // when
-      Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(1L, PageRequest.of(0, 10));
+      Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(사용자1.getId(), PageRequest.of(0, 10));
 
       // then
       assertThat(result.getContent()).hasSize(2);
@@ -73,9 +81,10 @@ public class NotificationJpaRepositoryTest {
     @Test
     void 공지사항을_포함한다() {
       // given
-      notificationRepository.save(new NotificationEntity(1L));
+      NotificationEntity 알림 = notificationRepository.save(new NotificationEntity(null));
 
-      announcementNotiRepository.save(new AnnouncementNotiEntity(1L, 1L, "title", "body"));
+      AnnouncementNotiEntity 공지사항 = announcementNotiRepository.save(
+          new AnnouncementNotiEntity(null, 알림.getId(), "title", "body"));
 
       // when
       Slice<NotificationResponseDTO> result = notificationRepository.findAllByUserId(1L, PageRequest.of(0, 10));

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
@@ -1,0 +1,94 @@
+package yapp.buddycon.app.notification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+import yapp.buddycon.app.common.MockAuthenticationArgumentResolver;
+import yapp.buddycon.app.notification.adapter.client.ReadNotificationController;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadNotificationControllerTest {
+
+  private MockMvc mockMvc;
+  private final String BASE_URL = "/api/v1/notifications";
+
+  @Mock
+  private ReadNotificationUseCase readUseCase;
+  @InjectMocks
+  private ReadNotificationController readController;
+  private final MockAuthenticationArgumentResolver argumentResolver = new MockAuthenticationArgumentResolver();
+
+  @BeforeEach
+  void init() {
+    mockMvc = MockMvcBuilders.standaloneSetup(readController)
+        .setControllerAdvice(new ExceptionHandlerExceptionResolver())
+        .setCustomArgumentResolvers(argumentResolver)
+        .build();
+  }
+
+  @Nested
+  class getNotifications {
+
+    String API_PATH = "";
+
+    @Test
+    void 데이터가_없을_경우_빈_리스트를_반환한다() throws Exception {
+      // given
+      when(readUseCase.getNotifications(anyLong(), any())).thenReturn(
+          new SliceImpl<>(Collections.emptyList()));
+
+      // when
+      final ResultActions resultActions = mockMvc.perform(
+          MockMvcRequestBuilders.get(BASE_URL + API_PATH)
+      );
+
+      // then
+      resultActions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.body.size").value("0"));
+    }
+
+    @Test
+    void 알림_목록을_반환한다() throws Exception {
+      // given
+      when(readUseCase.getNotifications(anyLong(), any())).thenReturn(
+          new SliceImpl<>(Arrays.asList(
+              new NotificationResponseDTO(1L, 1L, "title1", null, null, null, null),
+              new NotificationResponseDTO(2L, null, null, 1L, 7, 1L, "name1")
+          )
+      ));
+
+      // when
+      final ResultActions resultActions = mockMvc.perform(
+          MockMvcRequestBuilders.get(BASE_URL + API_PATH)
+      );
+
+      // then
+      resultActions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.body.size").value("2"));
+
+    }
+  }
+
+}

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -1,0 +1,65 @@
+package yapp.buddycon.app.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
+import yapp.buddycon.app.notification.application.service.ReadNotificationService;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadNotificationServiceTest {
+
+  @Mock
+  private NotificationQueryStorage queryStorage;
+  @InjectMocks
+  private ReadNotificationService readService;
+
+  @Nested
+  class getNotifications {
+
+    @Test
+    void 데이터가_없을_경우_빈_리스트를_반환한다() {
+      // given
+      when(queryStorage.findAll(anyLong(), any())).thenReturn(
+          new SliceImpl<>(Collections.emptyList())
+      );
+
+      // when
+      Slice<NotificationResponseDTO> resultList = readService.getNotifications(1l, new PagingDTO());
+
+      // then
+      assertThat(resultList.getSize()).isEqualTo(0);
+    }
+
+    @Test
+    void 알림_목록을_반환한다() {
+      // given
+      when(queryStorage.findAll(anyLong(), any())).thenReturn(
+          new SliceImpl<>(Arrays.asList(
+              new NotificationResponseDTO(1L, 1L, "title1", null, null, null, null),
+              new NotificationResponseDTO(2L, null, null, 1L, 7, 1L, "name1")))
+      );
+
+      // when
+      Slice<NotificationResponseDTO> resultList = readService.getNotifications(1l, new PagingDTO());
+
+      // then
+      assertThat(resultList.getSize()).isEqualTo(2);
+    }
+  }
+
+}

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -34,7 +34,7 @@ public class ReadNotificationServiceTest {
     @Test
     void 데이터가_없을_경우_빈_리스트를_반환한다() {
       // given
-      when(queryStorage.findAll(anyLong(), any())).thenReturn(
+      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
           new SliceImpl<>(Collections.emptyList())
       );
 
@@ -48,7 +48,7 @@ public class ReadNotificationServiceTest {
     @Test
     void 알림_목록을_반환한다() {
       // given
-      when(queryStorage.findAll(anyLong(), any())).thenReturn(
+      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
               new NotificationResponseDTO(1L, 1L, "title1", null, null, null, null),
               new NotificationResponseDTO(2L, null, null, 1L, 7, 1L, "name1")))


### PR DESCRIPTION
## 내용

- 알림 목록 조회 기능 추가
- 추후 확인 여부와 관련된 로직은 따로 이슈 등록하여 처리하겠습니다~

## 세부 내용

- API 추가 : `/api/v1/notifications`
- JPA 엔티티 추가
  - notification에 속하는 테이블의 경우 Suffix로 noti 사용
  - Notification
  - AnnouncementNotiEntity
  - GifticonExpirationAlertNotiEntity

## 관련 화면
<img width="1028" alt="image" src="https://github.com/Team-BuddyCon/BACKEND_V2/assets/77145383/bc167cc5-f08e-46e9-82c4-e6b723e9edf7">

close #34 