### PR TITLE
[Feature] 알림 목록 조회 시 확인 완료 처리

### DIFF
--- a/src/main/java/yapp/buddycon/BuddyconApplication.java
+++ b/src/main/java/yapp/buddycon/BuddyconApplication.java
@@ -2,7 +2,9 @@ package yapp.buddycon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BuddyconApplication {
 

--- a/src/main/java/yapp/buddycon/app/event/NotificationCheckingEvent.java
+++ b/src/main/java/yapp/buddycon/app/event/NotificationCheckingEvent.java
@@ -1,0 +1,10 @@
+package yapp.buddycon.app.event;
+
+import java.time.LocalDateTime;
+
+public record NotificationCheckingEvent(
+    Long userId,
+    LocalDateTime checkedAt
+) {
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/event/NotificationSettingEventListener.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/event/NotificationSettingEventListener.java
@@ -2,19 +2,31 @@ package yapp.buddycon.app.notification.adapter.event;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.event.NotificationSettingCreationEvent;
 import yapp.buddycon.app.notification.application.port.in.CreateNotificationSettingUseCase;
+import yapp.buddycon.app.notification.application.port.in.UpdateNotificationSettingUseCase;
 
 @RequiredArgsConstructor
 @Component
 public class NotificationSettingEventListener {
 
   private final CreateNotificationSettingUseCase createNotificationSettingUseCase;
+  private final UpdateNotificationSettingUseCase updateNotificationSettingUseCase;
 
   @EventListener
   public void handleCreationEvent(NotificationSettingCreationEvent event) {
     createNotificationSettingUseCase.create(event.userId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleCheckingEvent(NotificationCheckingEvent event) {
+    updateNotificationSettingUseCase.updateNotificationLastCheckedAt(event.userId(), event.checkedAt());
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationSettingEntity.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationSettingEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,11 +31,12 @@ public class NotificationSettingEntity extends BaseEntity {
   private boolean threeDaysBefore;
   private boolean oneDayBefore;
   private boolean theDay;
+  private LocalDateTime lastCheckedAt;
 
   @Builder
   public NotificationSettingEntity(Long id, Long userId, boolean activated,
       boolean fourteenDaysBefore, boolean sevenDaysBefore, boolean threeDaysBefore,
-      boolean oneDayBefore, boolean theDay) {
+      boolean oneDayBefore, boolean theDay, LocalDateTime lastCheckedAt) {
     this.id = id;
     this.userId = userId;
     this.activated = activated;
@@ -43,5 +45,6 @@ public class NotificationSettingEntity extends BaseEntity {
     this.threeDaysBefore = threeDaysBefore;
     this.oneDayBefore = oneDayBefore;
     this.theDay = theDay;
+    this.lastCheckedAt = lastCheckedAt;
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationSettingMapper.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationSettingMapper.java
@@ -16,6 +16,7 @@ public class NotificationSettingMapper {
         .threeDaysBefore(entity.isThreeDaysBefore())
         .oneDayBefore(entity.isOneDayBefore())
         .theDay(entity.isTheDay())
+        .lastCheckedAt(entity.getLastCheckedAt())
         .build();
   }
 
@@ -29,6 +30,7 @@ public class NotificationSettingMapper {
         .threeDaysBefore(notificationSetting.isThreeDaysBefore())
         .oneDayBefore(notificationSetting.isOneDayBefore())
         .theDay(notificationSetting.isTheDay())
+        .lastCheckedAt(notificationSetting.getLastCheckedAt())
         .build();
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/port/in/UpdateNotificationSettingUseCase.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/in/UpdateNotificationSettingUseCase.java
@@ -1,9 +1,12 @@
 package yapp.buddycon.app.notification.application.port.in;
 
+import java.time.LocalDateTime;
 import yapp.buddycon.app.notification.adapter.client.request.UpdateNotificationSettingDTO;
 
 public interface UpdateNotificationSettingUseCase {
 
   void updateNotificationSetting(UpdateNotificationSettingDTO dto, Long userId);
+
+  void updateNotificationLastCheckedAt(Long userId, LocalDateTime checkedAt);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/CreateNotificationSettingService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/CreateNotificationSettingService.java
@@ -1,5 +1,6 @@
 package yapp.buddycon.app.notification.application.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class CreateNotificationSettingService implements CreateNotificationSetti
       .threeDaysBefore(false)
       .oneDayBefore(true)
       .theDay(true)
+      .lastCheckedAt(LocalDateTime.now())
       .build();
 
     notificationSettingCommandStorage.save(notificationSetting);

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -1,10 +1,13 @@
 package yapp.buddycon.app.notification.application.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
@@ -15,9 +18,11 @@ import yapp.buddycon.app.notification.application.port.out.NotificationQueryStor
 public class ReadNotificationService implements ReadNotificationUseCase {
 
   private final NotificationQueryStorage queryStorage;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
   public Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto) {
+    applicationEventPublisher.publishEvent(new NotificationCheckingEvent(userId, LocalDateTime.now()));
     return queryStorage.findAllByUserId(userId, dto.toPageable());
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/UpdateNotificationSettingService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/UpdateNotificationSettingService.java
@@ -1,6 +1,8 @@
 package yapp.buddycon.app.notification.application.service;
 
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import yapp.buddycon.app.notification.adapter.client.request.UpdateNotificationSettingDTO;
@@ -27,4 +29,13 @@ public class UpdateNotificationSettingService implements UpdateNotificationSetti
     notificationSettingCommandStorage.save(notificationSetting);
   }
 
+  @Transactional(value = TxType.REQUIRES_NEW)
+  @Override
+  public void updateNotificationLastCheckedAt(Long userId, LocalDateTime checkedAt) {
+    NotificationSetting notificationSetting = notificationSettingQueryStorage.getByUserId(userId);
+
+    notificationSetting.updateLastCheckedAt(checkedAt);
+
+    notificationSettingCommandStorage.save(notificationSetting);
+  }
 }

--- a/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
@@ -28,4 +28,8 @@ public class NotificationSetting {
     this.theDay = theDay;
   }
 
+  public void updateLastCheckedAt(LocalDateTime lastCheckedAt) {
+    this.lastCheckedAt = lastCheckedAt;
+  }
+
 }

--- a/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
@@ -19,14 +19,13 @@ public class NotificationSetting {
   private LocalDateTime lastCheckedAt;
 
   public void update(boolean activated, boolean fourteenDaysBefore, boolean sevenDaysBefore,
-      boolean threeDaysBefore, boolean oneDayBefore, boolean theDay, LocalDateTime lastCheckedAt) {
+      boolean threeDaysBefore, boolean oneDayBefore, boolean theDay) {
     this.activated = activated;
     this.fourteenDaysBefore = fourteenDaysBefore;
     this.sevenDaysBefore = sevenDaysBefore;
     this.threeDaysBefore = threeDaysBefore;
     this.oneDayBefore = oneDayBefore;
     this.theDay = theDay;
-    this.lastCheckedAt = lastCheckedAt;
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/app/notification/domain/NotificationSetting.java
@@ -1,5 +1,6 @@
 package yapp.buddycon.app.notification.domain;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,15 +16,17 @@ public class NotificationSetting {
   private boolean threeDaysBefore;
   private boolean oneDayBefore;
   private boolean theDay;
+  private LocalDateTime lastCheckedAt;
 
   public void update(boolean activated, boolean fourteenDaysBefore, boolean sevenDaysBefore,
-      boolean threeDaysBefore, boolean oneDayBefore, boolean theDay) {
+      boolean threeDaysBefore, boolean oneDayBefore, boolean theDay, LocalDateTime lastCheckedAt) {
     this.activated = activated;
     this.fourteenDaysBefore = fourteenDaysBefore;
     this.sevenDaysBefore = sevenDaysBefore;
     this.threeDaysBefore = threeDaysBefore;
     this.oneDayBefore = oneDayBefore;
     this.theDay = theDay;
+    this.lastCheckedAt = lastCheckedAt;
   }
 
 }

--- a/src/test/java/yapp/buddycon/BuddyconApplicationTest.java
+++ b/src/test/java/yapp/buddycon/BuddyconApplicationTest.java
@@ -1,0 +1,13 @@
+package yapp.buddycon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BuddyconApplicationTest {
+
+  @Test
+  void contextLoads() {
+  }
+
+}

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import yapp.buddycon.app.common.request.PagingDTO;
@@ -25,6 +26,8 @@ public class ReadNotificationServiceTest {
 
   @Mock
   private NotificationQueryStorage queryStorage;
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
   @InjectMocks
   private ReadNotificationService readService;
 

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -3,6 +3,7 @@ package yapp.buddycon.app.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -17,6 +18,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
 import yapp.buddycon.app.notification.application.service.ReadNotificationService;
@@ -62,6 +64,20 @@ public class ReadNotificationServiceTest {
 
       // then
       assertThat(resultList.getSize()).isEqualTo(2);
+    }
+
+    @Test
+    void 알림_확인_이벤트를_발생시킨다() {
+      // given
+      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
+          new SliceImpl<>(Collections.emptyList())
+      );
+
+      // when
+      readService.getNotifications(1l, new PagingDTO());
+
+      // then
+      verify(applicationEventPublisher).publishEvent(any(NotificationCheckingEvent.class));
     }
   }
 

--- a/src/test/java/yapp/buddycon/app/notification/UpdateNotificationSettingServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/UpdateNotificationSettingServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,6 +43,23 @@ public class UpdateNotificationSettingServiceTest {
     // then
     verify(notificationSetting, times(1)).update(false, false, false, false, true, false);
     verify(notificationSettingCommandStorage, times(1)).save(notificationSetting);
+  }
+
+  @Test
+  void 알림_확인_일시를_변경한다() {
+    // given
+    final var userId = 1L;
+    final LocalDateTime dateTime = LocalDateTime.of(2021, 1, 1, 1, 10, 10);
+
+    NotificationSetting notificationSetting = mock(NotificationSetting.class);
+    when(notificationSettingQueryStorage.getByUserId(userId)).thenReturn(notificationSetting);
+
+    // when
+    service.updateNotificationLastCheckedAt(userId, dateTime);
+
+    // then
+    verify(notificationSetting).updateLastCheckedAt(dateTime);
+    verify(notificationSettingCommandStorage).save(notificationSetting);
   }
 
 }


### PR DESCRIPTION
## 내용

알림 목록 조회 시 최근 알림 확인 일시를 수정하도록 하였습니다.

## 변경사항

- Main 메소드에 JpaAuditing 어노테이션을 추가하였습니다.
  - BaseEntity에 있는 createdAt, updatedAt에 값을 추가해주기 위함
- NotificationSetting 엔티티에 최근 알림 확인 일시를 나타내는 lastCheckedAt 컬럼을 추가하였습니다.
- 알림 목록 조회를 했을 때 해당 유저의 lastCheckedAt 컬럼을 업데이트하도록 이벤트와 이벤트 리스너를 추가하였습니다.

## 설명

알림 확인 처리는 비교적 중요하지 않은 로직이라 생각하여 별도의 트랜잭션으로 수행할 수 있도록 Async와 TransactionalEventListener를 사용하였습니다!

close #44 