### PR TITLE
feat: 기프티콘 상태 수정 api

### DIFF
--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/GifticonException.java
@@ -8,6 +8,7 @@ public class GifticonException extends BadRequestException {
   @Getter
   public enum GifticonExceptionCode {
     GIFTICON_NOT_FOUND("기프티콘을 찾을 수 없습니다"),
+    GIFTICON_IS_ALREADY_THAT_STATUS("기프티콘이 이미 해당하는 사용 상태입니다."),
     ;
 
     private String message;

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/UpdateGifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/UpdateGifticonController.java
@@ -46,8 +46,7 @@ public class UpdateGifticonController {
             @PathVariable("gifticon-id") long gifticonId,
             @Parameter(name = "기프티콘 사용 여부") @RequestParam("used") boolean used
     ) {
-        boolean result = usecase.updateUsed(used, gifticonId, user.id());
-        if (result) return ApiResponse.success("기프티콘 사용 여부를 변경하였습니다.");
-        return ApiResponse.badRequest(GifticonExceptionCode.GIFTICON_IS_ALREADY_THAT_STATUS.getMessage(), null);
+        usecase.updateUsed(used, gifticonId, user.id());
+        return ApiResponse.success("기프티콘 사용 여부를 변경하였습니다.");
     }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/adapter/client/UpdateGifticonController.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/adapter/client/UpdateGifticonController.java
@@ -6,10 +6,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.app.common.AuthUser;
 import yapp.buddycon.app.common.response.ApiResponse;
 import yapp.buddycon.app.common.response.ResponseBody;
+import yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode;
 import yapp.buddycon.app.gifticon.adapter.client.request.GifticonUpdateDto;
 import yapp.buddycon.app.gifticon.application.port.in.UpdateGifticonUsecase;
 
@@ -30,5 +37,17 @@ public class UpdateGifticonController {
     ) {
         usecase.update(dto, gifticonId, user.id());
         return ApiResponse.success("기프티콘 수정을 완료하였습니다.");
+    }
+
+    @Operation(summary = "기프티콘 사용 여부 변경")
+    @PatchMapping("{gifticon-id}")
+    public ResponseEntity<ResponseBody> updateGifticonUsed(
+            @Parameter(hidden = true) AuthUser user,
+            @PathVariable("gifticon-id") long gifticonId,
+            @Parameter(name = "기프티콘 사용 여부") @RequestParam("used") boolean used
+    ) {
+        boolean result = usecase.updateUsed(used, gifticonId, user.id());
+        if (result) return ApiResponse.success("기프티콘 사용 여부를 변경하였습니다.");
+        return ApiResponse.badRequest(GifticonExceptionCode.GIFTICON_IS_ALREADY_THAT_STATUS.getMessage(), null);
     }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/in/UpdateGifticonUsecase.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/in/UpdateGifticonUsecase.java
@@ -5,5 +5,5 @@ import yapp.buddycon.app.gifticon.adapter.client.request.GifticonUpdateDto;
 public interface UpdateGifticonUsecase {
 
     void update(GifticonUpdateDto dto, Long gifticonId, Long userId);
-    boolean updateUsed(boolean used, Long gifticonId, Long userId);
+    void updateUsed(boolean used, Long gifticonId, Long userId);
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/port/in/UpdateGifticonUsecase.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/port/in/UpdateGifticonUsecase.java
@@ -5,4 +5,5 @@ import yapp.buddycon.app.gifticon.adapter.client.request.GifticonUpdateDto;
 public interface UpdateGifticonUsecase {
 
     void update(GifticonUpdateDto dto, Long gifticonId, Long userId);
+    boolean updateUsed(boolean used, Long gifticonId, Long userId);
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/UpdateGifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/UpdateGifticonService.java
@@ -30,13 +30,12 @@ public class UpdateGifticonService implements UpdateGifticonUsecase {
     }
 
     @Override
-    public boolean updateUsed(boolean used, Long gifticonId, Long userId) {
+    public void updateUsed(boolean used, Long gifticonId, Long userId) {
         Gifticon gifticon = queryStorage.getByGifticonIdAndUserId(gifticonId, userId);
-        System.out.println("used = " + used);
-        System.out.println("gifticon = " + gifticon.isUsed());
-        if(gifticon.isUsed() == used) return false;
+        if (gifticon.isUsed() == used) {
+            throw new BadRequestException(GifticonExceptionCode.GIFTICON_IS_ALREADY_THAT_STATUS.getMessage());
+        }
         gifticon.modifyUsed(used);
         commandStorage.save(gifticon);
-        return true;
     }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/application/service/UpdateGifticonService.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/application/service/UpdateGifticonService.java
@@ -1,8 +1,13 @@
 package yapp.buddycon.app.gifticon.application.service;
 
+import static yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode.GIFTICON_IS_ALREADY_THAT_STATUS;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import yapp.buddycon.app.common.response.BadRequestException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException;
+import yapp.buddycon.app.gifticon.adapter.GifticonException.GifticonExceptionCode;
 import yapp.buddycon.app.gifticon.adapter.client.request.GifticonUpdateDto;
 import yapp.buddycon.app.gifticon.application.port.in.UpdateGifticonUsecase;
 import yapp.buddycon.app.gifticon.application.port.out.GifticonCommandStorage;
@@ -22,5 +27,16 @@ public class UpdateGifticonService implements UpdateGifticonUsecase {
         Gifticon gifticon = queryStorage.getByGifticonIdAndUserId(gifticonId, userId);
         gifticon.modify(dto.name(), dto.memo(), dto.expireDate(), dto.store());
         commandStorage.save(gifticon);
+    }
+
+    @Override
+    public boolean updateUsed(boolean used, Long gifticonId, Long userId) {
+        Gifticon gifticon = queryStorage.getByGifticonIdAndUserId(gifticonId, userId);
+        System.out.println("used = " + used);
+        System.out.println("gifticon = " + gifticon.isUsed());
+        if(gifticon.isUsed() == used) return false;
+        gifticon.modifyUsed(used);
+        commandStorage.save(gifticon);
+        return true;
     }
 }

--- a/src/main/java/yapp/buddycon/app/gifticon/domain/Gifticon.java
+++ b/src/main/java/yapp/buddycon/app/gifticon/domain/Gifticon.java
@@ -41,6 +41,10 @@ public class Gifticon {
         this.gifticonStore = store;
     }
 
+    public void modifyUsed(boolean used) {
+        this.used = used;
+    }
+
     public void delete() {
         this.deleted = true;
     }

--- a/src/test/java/yapp/buddycon/app/gifticon/ReadGifticonControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/ReadGifticonControllerTest.java
@@ -95,4 +95,10 @@ public class ReadGifticonControllerTest {
     }
   }
 
+  @Test
+  void dd() {
+    String repeat = "updatedContent".repeat(500);
+    System.out.println(repeat.length());
+  }
+
 }

--- a/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonControllerTest.java
@@ -134,7 +134,7 @@ class UpdateGifticonControllerTest {
     void 기프티콘의_사용상태를_변경한다() throws Exception {
         // given
         when(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(new AuthUser(1L));
-        when(usecase.updateUsed(anyBoolean(), any(), any())).thenReturn(true);
+        doNothing().when(usecase).updateUsed(anyBoolean(), any(), any());
 
         // when
         final var response = RestAssured.given().log().all()
@@ -147,24 +147,5 @@ class UpdateGifticonControllerTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
-    void 기프티콘의_사용상태가_이미_요청과_같다면_예외를_반환한다() throws Exception {
-        // given
-        when(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(new AuthUser(1L));
-        when(usecase.updateUsed(false, 1L, 1L)).thenReturn(false);
-
-        // when
-        final var response = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .queryParam("used", false)
-                .when().patch("/api/v1/gifticons/1")
-                .then()
-                .log().all()
-                .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonServiceTest.java
@@ -50,4 +50,29 @@ class UpdateGifticonServiceTest {
 
         verify(commandStorage, times(1)).save(any(Gifticon.class));
     }
+
+    @Test
+    void 기프티콘_상태_수정_성공시_save_command가_한번_수행된다() {
+        final var gifticonId = 1L;
+        final var userId = 1L;
+        final var request = true;
+
+        when(queryStorage.getByGifticonIdAndUserId(gifticonId, userId)).thenReturn(new Gifticon(gifticonId, userId, "imageUrl", "name", "memo", LocalDate.now(), false, false, GifticonStore.CU));
+        service.updateUsed(request, gifticonId, userId);
+
+        verify(commandStorage, times(1)).save(any(Gifticon.class));
+    }
+
+    @Test
+    void 기프티콘_상태_수정_실패시_save_command가_수행되지_않는다() {
+        final var gifticonId = 1L;
+        final var userId = 1L;
+        final var gifticon = new Gifticon(gifticonId, userId, "imageUrl", "name", "memo", LocalDate.now(), false, false, GifticonStore.CU);
+        final var request = false;
+
+        when(queryStorage.getByGifticonIdAndUserId(gifticonId, userId)).thenReturn(gifticon);
+        service.updateUsed(request, gifticonId, userId);
+
+        verifyNoInteractions(commandStorage);
+    }
 }

--- a/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/UpdateGifticonServiceTest.java
@@ -14,6 +14,7 @@ import yapp.buddycon.app.gifticon.domain.GifticonStore;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,8 +72,8 @@ class UpdateGifticonServiceTest {
         final var request = false;
 
         when(queryStorage.getByGifticonIdAndUserId(gifticonId, userId)).thenReturn(gifticon);
-        service.updateUsed(request, gifticonId, userId);
 
+        assertThatThrownBy(() -> service.updateUsed(request, gifticonId, userId));
         verifyNoInteractions(commandStorage);
     }
 }


### PR DESCRIPTION
- 기프티콘 상태 수정 api를 구현하였습니다.
- requestparam으로 변경하고자하는 상태를 boolean으로 받아와 상태를 변경합니다.
  - 만약 현 상태와 바꾸고자하는 상태가 같다면 예외가 발생합니다.