### PR TITLE
[Feature] 알림 목록 조회 시 기존에 확인 했는지에 대한 여부 컬럼 추가

### DIFF
--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
@@ -1,7 +1,10 @@
 package yapp.buddycon.app.notification.adapter.client.response;
 
+import java.time.LocalDateTime;
+
 public record NotificationResponseDTO(
     Long notificationId,
+    LocalDateTime notificationCreatedAt,
     Long announcementId,
     String announcementTitle,
     Long GifticonExpirationAlertId,

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/NotificationResponseDTO.java
@@ -10,8 +10,8 @@ public record NotificationResponseDTO(
     Long GifticonExpirationAlertId,
     Integer gifticonDaysLeft,
     Long gifticonId,
-    String gifticonName
-//    boolean checked
+    String gifticonName,
+    boolean checked
 ) {
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaNotificationQueryStorage.java
@@ -1,5 +1,6 @@
 package yapp.buddycon.app.notification.adapter.infra;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,7 +16,7 @@ public class JpaNotificationQueryStorage implements NotificationQueryStorage {
   private final NotificationJpaRepository notificationJpaRepository;
 
   @Override
-  public Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable) {
-    return notificationJpaRepository.findAllByUserId(userId, pageable);
+  public Slice<NotificationResponseDTO> findAllByUserId(long userId, LocalDateTime lastCheckedAt, Pageable pageable) {
+    return notificationJpaRepository.findAllByUserId(userId, lastCheckedAt, pageable);
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
@@ -10,7 +10,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
 
   @Query(value = """
     SELECT new yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO
-      (n.id, an.id, an.title, gen.id, gen.daysLeft, g.id, g.name)
+      (n.id, n.createdAt, an.id, an.title, gen.id, gen.daysLeft, g.id, g.name)
     FROM NotificationEntity n
     LEFT OUTER JOIN AnnouncementNotiEntity an
       ON n.id = an.notificationId

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/NotificationJpaRepository.java
@@ -1,5 +1,6 @@
 package yapp.buddycon.app.notification.adapter.infra.jpa;
 
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,7 +11,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
 
   @Query(value = """
     SELECT new yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO
-      (n.id, n.createdAt, an.id, an.title, gen.id, gen.daysLeft, g.id, g.name)
+      (n.id, n.createdAt, an.id, an.title, gen.id, gen.daysLeft, g.id, g.name, (n.createdAt  < CAST(:lastCheckedAt AS localdatetime)))
     FROM NotificationEntity n
     LEFT OUTER JOIN AnnouncementNotiEntity an
       ON n.id = an.notificationId
@@ -21,6 +22,6 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
     WHERE g.userId = :userId
        OR g.userId IS NULL
   """)
-  Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable);
+  Slice<NotificationResponseDTO> findAllByUserId(long userId, LocalDateTime lastCheckedAt, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/out/NotificationQueryStorage.java
@@ -1,11 +1,12 @@
 package yapp.buddycon.app.notification.application.port.out;
 
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 
 public interface NotificationQueryStorage {
 
-  Slice<NotificationResponseDTO> findAllByUserId(long userId, Pageable pageable);
+  Slice<NotificationResponseDTO> findAllByUserId(long userId, LocalDateTime lastCheckedAt, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -11,6 +11,8 @@ import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
+import yapp.buddycon.app.notification.application.port.out.NotificationSettingQueryStorage;
+import yapp.buddycon.app.notification.domain.NotificationSetting;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +20,15 @@ import yapp.buddycon.app.notification.application.port.out.NotificationQueryStor
 public class ReadNotificationService implements ReadNotificationUseCase {
 
   private final NotificationQueryStorage queryStorage;
+  private final NotificationSettingQueryStorage notificationSettingQueryStorage;
   private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
   public Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto) {
     applicationEventPublisher.publishEvent(new NotificationCheckingEvent(userId, LocalDateTime.now()));
-    return queryStorage.findAllByUserId(userId, dto.toPageable());
+
+    NotificationSetting notificationSetting = notificationSettingQueryStorage.getByUserId(userId);
+
+    return queryStorage.findAllByUserId(userId, notificationSetting.getLastCheckedAt(), dto.toPageable());
   }
 }

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
@@ -74,8 +74,8 @@ public class ReadNotificationControllerTest {
       // given
       when(readUseCase.getNotifications(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null),
-              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1")
+              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null, false),
+              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1", false)
           )
       ));
 

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,8 +74,8 @@ public class ReadNotificationControllerTest {
       // given
       when(readUseCase.getNotifications(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new NotificationResponseDTO(1L, 1L, "title1", null, null, null, null),
-              new NotificationResponseDTO(2L, null, null, 1L, 7, 1L, "name1")
+              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null),
+              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1")
           )
       ));
 

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -3,12 +3,14 @@ package yapp.buddycon.app.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,13 +24,17 @@ import yapp.buddycon.app.common.request.PagingDTO;
 import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
+import yapp.buddycon.app.notification.application.port.out.NotificationSettingQueryStorage;
 import yapp.buddycon.app.notification.application.service.ReadNotificationService;
+import yapp.buddycon.app.notification.domain.NotificationSetting;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadNotificationServiceTest {
 
   @Mock
-  private NotificationQueryStorage queryStorage;
+  private NotificationQueryStorage notificationQueryStorage;
+  @Mock
+  private NotificationSettingQueryStorage notificationSettingQueryStorage;
   @Mock
   private ApplicationEventPublisher applicationEventPublisher;
   @InjectMocks
@@ -36,11 +42,17 @@ public class ReadNotificationServiceTest {
 
   @Nested
   class getNotifications {
+    @BeforeEach
+    void setUp() {
+      NotificationSetting notificationSetting = mock(NotificationSetting.class);
+      when(notificationSettingQueryStorage.getByUserId(anyLong())).thenReturn(notificationSetting);
+      when(notificationSetting.getLastCheckedAt()).thenReturn(LocalDateTime.now());
+    }
 
     @Test
     void 데이터가_없을_경우_빈_리스트를_반환한다() {
       // given
-      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
+      when(notificationQueryStorage.findAllByUserId(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Collections.emptyList())
       );
 
@@ -54,10 +66,10 @@ public class ReadNotificationServiceTest {
     @Test
     void 알림_목록을_반환한다() {
       // given
-      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
+      when(notificationQueryStorage.findAllByUserId(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null),
-              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1")))
+              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null, false),
+              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1", false)))
       );
 
       // when
@@ -70,7 +82,7 @@ public class ReadNotificationServiceTest {
     @Test
     void 알림_확인_이벤트를_발생시킨다() {
       // given
-      when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
+      when(notificationQueryStorage.findAllByUserId(anyLong(), any(), any())).thenReturn(
           new SliceImpl<>(Collections.emptyList())
       );
 

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Nested;
@@ -55,8 +56,8 @@ public class ReadNotificationServiceTest {
       // given
       when(queryStorage.findAllByUserId(anyLong(), any())).thenReturn(
           new SliceImpl<>(Arrays.asList(
-              new NotificationResponseDTO(1L, 1L, "title1", null, null, null, null),
-              new NotificationResponseDTO(2L, null, null, 1L, 7, 1L, "name1")))
+              new NotificationResponseDTO(1L, LocalDateTime.now(), 1L, "title1", null, null, null, null),
+              new NotificationResponseDTO(2L, LocalDateTime.now(), null, null, 1L, 7, 1L, "name1")))
       );
 
       // when


### PR DESCRIPTION
# 내용

알림 목록 조회 시 반환하는 DTO에 '알림 생성 일시'와 '확인 여부' 컬럼을 추가하였습니다.

# 변경사항

- 알림 목록 조회 쿼리문 수정
- NotificationResponseDTO 컬럼 추가
- 테스트 코드 및 로직 반영

# 설명

Repository 테스트 시 EntityManager, Native Query 사용

이번에 수정된 쿼리문은 JpaAuditing 기능을 통해 자동으로 입력되는 값인 createdAt(생성 일시)을 활용합니다. 이를 테스트를 하기 위해 Native Query로 해당 값을 직접 넣어 줌으로써 테스트 코드를 작성했습니다.

close #45 