### PR TITLE
[Feature] 공지사항 상세 조회 API

### DIFF
--- a/src/main/java/yapp/buddycon/app/notification/adapter/AnnouncementNotiException.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/AnnouncementNotiException.java
@@ -1,0 +1,24 @@
+package yapp.buddycon.app.notification.adapter;
+
+import lombok.Getter;
+import yapp.buddycon.app.common.response.BadRequestException;
+
+public class AnnouncementNotiException extends BadRequestException {
+
+  @Getter
+  public enum AnnouncementNotiExceptionCode {
+    ANNOUNCEMENT_NOTI_NOT_FOUND("공지사항을 찾을 수 없습니다"),
+    ;
+
+    private String message;
+
+    AnnouncementNotiExceptionCode(String message) {
+      this.message = message;
+    }
+  }
+
+  public AnnouncementNotiException(AnnouncementNotiExceptionCode code) {
+    super(code.message);
+  }
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
@@ -39,5 +39,4 @@ public class ReadNotificationController {
         readUseCase.getAnnouncementNoti(authUser.id(), announcementId));
   }
 
-
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.app.common.AuthUser;
@@ -29,5 +30,14 @@ public class ReadNotificationController {
     return ApiResponse.successWithBody("알림 목록을 성공적으로 조회하였습니다.",
         readUseCase.getNotifications(authUser.id(), dto));
   }
+
+  @Operation(summary = "공지사항 단건 조회")
+  @GetMapping("/announcement/{announcement-id}")
+  public ResponseEntity<?> getAnnouncementNoti(
+      @Parameter(hidden = true) AuthUser authUser, @PathVariable("announcement-id") long announcementId) {
+    return ApiResponse.successWithBody("공지사항을 성공적으로 조회하였습니다.",
+        readUseCase.getAnnouncementNoti(authUser.id(), announcementId));
+  }
+
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/ReadNotificationController.java
@@ -36,7 +36,7 @@ public class ReadNotificationController {
   public ResponseEntity<?> getAnnouncementNoti(
       @Parameter(hidden = true) AuthUser authUser, @PathVariable("announcement-id") long announcementId) {
     return ApiResponse.successWithBody("공지사항을 성공적으로 조회하였습니다.",
-        readUseCase.getAnnouncementNoti(authUser.id(), announcementId));
+        readUseCase.getAnnouncementNoti(announcementId));
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/AnnouncementNotiResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/AnnouncementNotiResponseDTO.java
@@ -1,0 +1,12 @@
+package yapp.buddycon.app.notification.adapter.client.response;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementNotiResponseDTO(
+    Long announcementId,
+    String title,
+    String body,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/client/response/AnnouncementNotiResponseDTO.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/client/response/AnnouncementNotiResponseDTO.java
@@ -3,7 +3,7 @@ package yapp.buddycon.app.notification.adapter.client.response;
 import java.time.LocalDateTime;
 
 public record AnnouncementNotiResponseDTO(
-    Long announcementId,
+    Long announcementNotiId,
     String title,
     String body,
     LocalDateTime createdAt

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
@@ -2,16 +2,22 @@ package yapp.buddycon.app.notification.adapter.infra;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.notification.adapter.AnnouncementNotiException;
+import yapp.buddycon.app.notification.adapter.AnnouncementNotiException.AnnouncementNotiExceptionCode;
 import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
+import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiJpaRepository;
 import yapp.buddycon.app.notification.application.port.out.AnnouncementNotiQueryStorage;
 
 @RequiredArgsConstructor
 @Component
 public class JpaAnnouncementNotiQueryStorage implements AnnouncementNotiQueryStorage {
 
+  private final AnnouncementNotiJpaRepository announcementNotiJpaRepository;
+
   @Override
   public AnnouncementNotiResponseDTO getById(Long id) {
-    // TODO implement
-    return null;
+    return announcementNotiJpaRepository.findByIdAsResponseDTO(id)
+        .orElseThrow(() -> new AnnouncementNotiException(
+            AnnouncementNotiExceptionCode.ANNOUNCEMENT_NOTI_NOT_FOUND));
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
@@ -1,0 +1,17 @@
+package yapp.buddycon.app.notification.adapter.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
+import yapp.buddycon.app.notification.application.port.out.AnnouncementNotiQueryStorage;
+
+@RequiredArgsConstructor
+@Component
+public class JpaAnnouncementNotiQueryStorage implements AnnouncementNotiQueryStorage {
+
+  @Override
+  public AnnouncementNotiResponseDTO getByIdAndUserId(Long id, Long userId) {
+    // TODO implement
+    return null;
+  }
+}

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/JpaAnnouncementNotiQueryStorage.java
@@ -10,7 +10,7 @@ import yapp.buddycon.app.notification.application.port.out.AnnouncementNotiQuery
 public class JpaAnnouncementNotiQueryStorage implements AnnouncementNotiQueryStorage {
 
   @Override
-  public AnnouncementNotiResponseDTO getByIdAndUserId(Long id, Long userId) {
+  public AnnouncementNotiResponseDTO getById(Long id) {
     // TODO implement
     return null;
   }

--- a/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiJpaRepository.java
+++ b/src/main/java/yapp/buddycon/app/notification/adapter/infra/jpa/AnnouncementNotiJpaRepository.java
@@ -1,7 +1,18 @@
 package yapp.buddycon.app.notification.adapter.infra.jpa;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
 
 public interface AnnouncementNotiJpaRepository extends JpaRepository<AnnouncementNotiEntity, Long> {
+
+  @Query(value = """
+    SELECT new yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO
+      (an.id, an.title, an.body, an.createdAt)
+    FROM AnnouncementNotiEntity an
+    WHERE an.id = :id
+  """)
+  Optional<AnnouncementNotiResponseDTO> findByIdAsResponseDTO(Long id);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
@@ -9,6 +9,6 @@ public interface ReadNotificationUseCase {
 
   Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto);
 
-  AnnouncementNotiResponseDTO getAnnouncementNoti(Long userId, Long announcementId);
+  AnnouncementNotiResponseDTO getAnnouncementNoti(Long announcementId);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/in/ReadNotificationUseCase.java
@@ -2,10 +2,13 @@ package yapp.buddycon.app.notification.application.port.in;
 
 import org.springframework.data.domain.Slice;
 import yapp.buddycon.app.common.request.PagingDTO;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 
 public interface ReadNotificationUseCase {
 
   Slice<NotificationResponseDTO> getNotifications(Long userId, PagingDTO dto);
+
+  AnnouncementNotiResponseDTO getAnnouncementNoti(Long userId, Long announcementId);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/port/out/AnnouncementNotiQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/out/AnnouncementNotiQueryStorage.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.app.notification.application.port.out;
+
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
+
+public interface AnnouncementNotiQueryStorage {
+
+  AnnouncementNotiResponseDTO getByIdAndUserId(Long id, Long userId);
+
+}

--- a/src/main/java/yapp/buddycon/app/notification/application/port/out/AnnouncementNotiQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/port/out/AnnouncementNotiQueryStorage.java
@@ -4,6 +4,6 @@ import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiRe
 
 public interface AnnouncementNotiQueryStorage {
 
-  AnnouncementNotiResponseDTO getByIdAndUserId(Long id, Long userId);
+  AnnouncementNotiResponseDTO getById(Long id);
 
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.app.common.request.PagingDTO;
 import yapp.buddycon.app.event.NotificationCheckingEvent;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
@@ -30,5 +31,11 @@ public class ReadNotificationService implements ReadNotificationUseCase {
     NotificationSetting notificationSetting = notificationSettingQueryStorage.getByUserId(userId);
 
     return queryStorage.findAllByUserId(userId, notificationSetting.getLastCheckedAt(), dto.toPageable());
+  }
+
+  @Override
+  public AnnouncementNotiResponseDTO getAnnouncementNoti(Long userId, Long announcementId) {
+    // TODO implement
+    return null;
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -11,6 +11,7 @@ import yapp.buddycon.app.event.NotificationCheckingEvent;
 import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
 import yapp.buddycon.app.notification.application.port.in.ReadNotificationUseCase;
+import yapp.buddycon.app.notification.application.port.out.AnnouncementNotiQueryStorage;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
 import yapp.buddycon.app.notification.application.port.out.NotificationSettingQueryStorage;
 import yapp.buddycon.app.notification.domain.NotificationSetting;
@@ -22,6 +23,7 @@ public class ReadNotificationService implements ReadNotificationUseCase {
 
   private final NotificationQueryStorage queryStorage;
   private final NotificationSettingQueryStorage notificationSettingQueryStorage;
+  private final AnnouncementNotiQueryStorage announcementNotiQueryStorage;
   private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
@@ -35,7 +37,6 @@ public class ReadNotificationService implements ReadNotificationUseCase {
 
   @Override
   public AnnouncementNotiResponseDTO getAnnouncementNoti(Long userId, Long announcementId) {
-    // TODO implement
-    return null;
+    return announcementNotiQueryStorage.getByIdAndUserId(userId, announcementId);
   }
 }

--- a/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
+++ b/src/main/java/yapp/buddycon/app/notification/application/service/ReadNotificationService.java
@@ -36,7 +36,7 @@ public class ReadNotificationService implements ReadNotificationUseCase {
   }
 
   @Override
-  public AnnouncementNotiResponseDTO getAnnouncementNoti(Long userId, Long announcementId) {
-    return announcementNotiQueryStorage.getByIdAndUserId(userId, announcementId);
+  public AnnouncementNotiResponseDTO getAnnouncementNoti(Long announcementId) {
+    return announcementNotiQueryStorage.getById(announcementId);
   }
 }

--- a/src/test/java/yapp/buddycon/app/notification/AnnouncementNotiJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/AnnouncementNotiJpaRepositoryTest.java
@@ -1,0 +1,60 @@
+package yapp.buddycon.app.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
+import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.AnnouncementNotiJpaRepository;
+import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationEntity;
+import yapp.buddycon.app.notification.adapter.infra.jpa.NotificationJpaRepository;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+public class AnnouncementNotiJpaRepositoryTest {
+
+  @Autowired
+  private AnnouncementNotiJpaRepository announcementNotiJpaRepository;
+  @Autowired
+  private NotificationJpaRepository notificationJpaRepository;
+
+  @Nested
+  class findByIdAsResponseDTO {
+
+    @Test
+    void 요청한_공지사항이_존재하는_경우_DTO를_반환한다() {
+      // given
+      NotificationEntity notification1 = notificationJpaRepository.save(new NotificationEntity(null));
+      AnnouncementNotiEntity announcementNoti = announcementNotiJpaRepository.save(
+          new AnnouncementNotiEntity(null, notification1.getId(), "body", "body"));
+
+      // when
+      Optional<AnnouncementNotiResponseDTO> result = announcementNotiJpaRepository.findByIdAsResponseDTO(
+          announcementNoti.getId());
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().announcementNotiId()).isEqualTo(announcementNoti.getId());
+      assertThat(result.get().title()).isEqualTo(announcementNoti.getTitle());
+      assertThat(result.get().body()).isEqualTo(announcementNoti.getBody());
+    }
+
+    @Test
+    void 요청한_공지사항이_존재하지_않는_경우_빈_옵셔널을_반환한다() {
+      // given
+
+      // when
+      Optional<AnnouncementNotiResponseDTO> result = announcementNotiJpaRepository.findByIdAsResponseDTO(1l);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+
+}

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
@@ -120,7 +120,7 @@ public class ReadNotificationControllerTest {
     }
 
     @Test
-    void 공지사항_단건이_없을_경우_404를_반환한다() throws Exception {
+    void 공지사항_단건이_없을_경우_400을_반환한다() throws Exception {
       // given
       doThrow(new AnnouncementNotiException(AnnouncementNotiExceptionCode.ANNOUNCEMENT_NOTI_NOT_FOUND))
           .when(readUseCase).getAnnouncementNoti(anyLong());

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationControllerTest.java
@@ -104,7 +104,7 @@ public class ReadNotificationControllerTest {
     @Test
     void 공지사항_단건을_반환한다() throws Exception {
       // given
-      when(readUseCase.getAnnouncementNoti(anyLong(), anyLong())).thenReturn(
+      when(readUseCase.getAnnouncementNoti(anyLong())).thenReturn(
           new AnnouncementNotiResponseDTO(1L, "title1", "body1", LocalDateTime.now())
       );
 
@@ -123,7 +123,7 @@ public class ReadNotificationControllerTest {
     void 공지사항_단건이_없을_경우_404를_반환한다() throws Exception {
       // given
       doThrow(new AnnouncementNotiException(AnnouncementNotiExceptionCode.ANNOUNCEMENT_NOTI_NOT_FOUND))
-          .when(readUseCase).getAnnouncementNoti(anyLong(), anyLong());
+          .when(readUseCase).getAnnouncementNoti(anyLong());
 
       // when
       final ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -22,7 +22,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import yapp.buddycon.app.common.request.PagingDTO;
 import yapp.buddycon.app.event.NotificationCheckingEvent;
+import yapp.buddycon.app.notification.adapter.client.response.AnnouncementNotiResponseDTO;
 import yapp.buddycon.app.notification.adapter.client.response.NotificationResponseDTO;
+import yapp.buddycon.app.notification.application.port.out.AnnouncementNotiQueryStorage;
 import yapp.buddycon.app.notification.application.port.out.NotificationQueryStorage;
 import yapp.buddycon.app.notification.application.port.out.NotificationSettingQueryStorage;
 import yapp.buddycon.app.notification.application.service.ReadNotificationService;
@@ -35,6 +37,8 @@ public class ReadNotificationServiceTest {
   private NotificationQueryStorage notificationQueryStorage;
   @Mock
   private NotificationSettingQueryStorage notificationSettingQueryStorage;
+  @Mock
+  private AnnouncementNotiQueryStorage announcementNotiQueryStorage;
   @Mock
   private ApplicationEventPublisher applicationEventPublisher;
   @InjectMocks
@@ -60,7 +64,7 @@ public class ReadNotificationServiceTest {
       Slice<NotificationResponseDTO> resultList = readService.getNotifications(1l, new PagingDTO());
 
       // then
-      assertThat(resultList.getSize()).isEqualTo(0);
+      assertThat(resultList.getSize()).isZero();
     }
 
     @Test
@@ -91,6 +95,28 @@ public class ReadNotificationServiceTest {
 
       // then
       verify(applicationEventPublisher).publishEvent(any(NotificationCheckingEvent.class));
+    }
+  }
+
+  @Nested
+  class getAnnouncementNoti {
+
+    @Test
+    void 공지사항_알림을_반환한다() {
+      // given
+      LocalDateTime today = LocalDateTime.now();
+      when(announcementNotiQueryStorage.getByIdAndUserId(anyLong(), anyLong())).thenReturn(
+          new AnnouncementNotiResponseDTO(1L, "title", "body", today)
+      );
+
+      // when
+      AnnouncementNotiResponseDTO result = readService.getAnnouncementNoti(1L, 1L);
+
+      // then
+      assertThat(result.announcementNotiId()).isEqualTo(1L);
+      assertThat(result.title()).isEqualTo("title");
+      assertThat(result.body()).isEqualTo("body");
+      assertThat(result.createdAt()).isEqualTo(today);
     }
   }
 

--- a/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/ReadNotificationServiceTest.java
@@ -105,12 +105,12 @@ public class ReadNotificationServiceTest {
     void 공지사항_알림을_반환한다() {
       // given
       LocalDateTime today = LocalDateTime.now();
-      when(announcementNotiQueryStorage.getByIdAndUserId(anyLong(), anyLong())).thenReturn(
+      when(announcementNotiQueryStorage.getById(anyLong())).thenReturn(
           new AnnouncementNotiResponseDTO(1L, "title", "body", today)
       );
 
       // when
-      AnnouncementNotiResponseDTO result = readService.getAnnouncementNoti(1L, 1L);
+      AnnouncementNotiResponseDTO result = readService.getAnnouncementNoti(1L);
 
       // then
       assertThat(result.announcementNotiId()).isEqualTo(1L);


### PR DESCRIPTION
## 내용

알림 목록에서 공지사항을 눌렀을 때 볼 수 있는 화면입니다. 해당 화면에서 사용할 공지사항 단건 조회 API를 추가하였습니다.

![image](https://github.com/Team-BuddyCon/BACKEND_V2/assets/77145383/55b80bb2-3919-4b78-990b-93cc444bb9bb)

## 변경사항

- `GET::/api/v1/notifications/announcement/{announcement-id}` API 추가

## 설명

하향식으로 TDD 했습니다 ㅎㅎ 커밋으로 보실 수 있어요!

close #39