### PR TITLE
[Feature] 로그아웃 API

### DIFF
--- a/src/main/java/yapp/buddycon/app/auth/adapter/client/LoginController.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/client/LoginController.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.app.auth.adapter.client;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.app.auth.application.port.in.AuthUsecase;
 import yapp.buddycon.app.auth.application.service.TokenDto;
+import yapp.buddycon.app.common.AuthUser;
 import yapp.buddycon.app.common.response.ResponseBody;
 import yapp.buddycon.app.common.response.ApiResponse;
 
@@ -27,6 +29,13 @@ public class LoginController {
     public ResponseEntity<ResponseBody> login(@RequestBody @Valid LoginRequest request) {
         TokenDto tokenDto = authUsecase.login(request);
         return ApiResponse.successWithBody("로그인에 성공하였습니다.", tokenDto);
+    }
+
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<ResponseBody> logout(@Parameter(hidden = true) AuthUser authUser) {
+        authUsecase.logout(authUser.id());
+        return ApiResponse.success("로그아웃에 성공하였습니다.");
     }
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/redis/RedisRefreshTokenStorage.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/redis/RedisRefreshTokenStorage.java
@@ -27,4 +27,9 @@ public class RedisRefreshTokenStorage implements CacheStorage<String, String> {
   public void save(String key, String value, long expireTime) {
     redisTemplate.opsForValue().set("RT:" + key, value, expireTime, TimeUnit.MILLISECONDS);
   }
+
+  @Override
+  public void delete(String key) {
+    redisTemplate.delete("RT:" + key);
+  }
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/port/in/AuthUsecase.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/in/AuthUsecase.java
@@ -7,4 +7,6 @@ public interface AuthUsecase {
 
   TokenDto login(LoginRequest request);
 
+  void logout(Long userId);
+
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/port/out/CacheStorage.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/out/CacheStorage.java
@@ -4,4 +4,5 @@ public interface CacheStorage<K, V> {
   void save(K key, V value);
   V get(K key);
   void save(K key, V value, long expireTime);
+  void delete(K key);
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.auth.application.port.in.AuthUsecase;
+import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 import yapp.buddycon.app.user.domain.User;
 
@@ -15,10 +16,16 @@ public class AuthService implements AuthUsecase {
 
     private final SignUpDecider signUpDecider;
     private final TokenProvider tokenProvider;
+    private final CacheStorage cacheStorage;
 
     @Override
     public TokenDto login(LoginRequest request) {
         User user = signUpDecider.decide(request);
         return tokenProvider.provide(user);
+    }
+
+    @Override
+    public void logout(Long userId) {
+        cacheStorage.delete(userId.toString());
     }
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -23,18 +23,19 @@ public class SignUpDecider {
   public User decide(LoginRequest request) {
     OAuthMemberInfo memberInfo = oAuthUserInfoApi.call(request.oauthAccessToken());
     Long clientId = memberInfo.id();
-    Optional<User> byClientId = userQueryStorage.findByClientId(clientId);
 
-    if (byClientId.isPresent()) {
-      return byClientId.get();
+    // 존재하는 유저라면 그대로 반환
+    Optional<User> existingUser = userQueryStorage.findByClientId(clientId);
+    if (existingUser.isPresent()) {
+      return existingUser.get();
     }
 
+    // 존재하지 않는 유저라면 생성
     User createdUser = userCommandStorage.save(
         new User(null, clientId, request.nickname(), request.email(), request.gender(),
             request.age()));
 
     applicationEventPublisher.publishEvent(new NotificationSettingCreationEvent(createdUser.id()));
-
     return createdUser;
   }
 }

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.service.AuthService;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.auth.application.service.SignUpDecider;
@@ -16,10 +17,10 @@ import static org.mockito.Mockito.verify;
 class AuthServiceTest {
 
     @Test
-    void one_invocation_of_signup_when_login(@Mock SignUpDecider signUpDecider, @Mock TokenProvider tokenProvider) {
+    void one_invocation_of_signup_when_login(@Mock SignUpDecider signUpDecider, @Mock TokenProvider tokenProvider, @Mock CacheStorage cacheStorage) {
         // given
         var oauthAccessToken = "oauthAccessToken";
-        var authService = new AuthService(signUpDecider, tokenProvider);
+        var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage);
         var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
 
         // when


### PR DESCRIPTION
# 내용

로그아웃 API를 추가하였습니다.
추가적으로 SignUpDecider의 코드 가독성을 위해 주석과 변수명을 수정하였습니다.

# 메모

현재는 Refresh 토큰만 Redis에 저장하고 로그아웃 시 Redis에서 삭제해주고 있습니다.
그러나 AccessToken은 그대로 살아있다는 문제가 있는데요. 이를 해결하기 위해서는 로그아웃 시 AccessToken을 블랙리스트로 Redis에 저장하여 추후 해당 AccessToken으로 들어오는 요청에 대해 Exception을 던지면 됩니다.

저는 위에서 말씀드린 해결 방법을 적용하지 않았는데요. 이는 모든 요청 시 Redis 메모리를 확인해야 한다는 점과, 안드에서 AccessToken을 삭제할 것이기 때문에 토큰이 탈취되지 않는 이상 문제가 없다고 생각했습니다. 탈취가 되더라도 Refresh할 수 없기 때문에 AccessToken의 유효시간이 지나면 자동으로 만료가 되기도 하구요.

의견 부탁드립니다~

close #51 