### PR TITLE
[Feature] JWT 토큰 재발행 API 추가

### DIFF
--- a/src/main/java/yapp/buddycon/app/auth/adapter/client/LoginController.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/client/LoginController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.auth.adapter.client.request.ReissueRequestDto;
 import yapp.buddycon.app.auth.application.port.in.AuthUsecase;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.common.AuthUser;
@@ -36,6 +37,13 @@ public class LoginController {
     public ResponseEntity<ResponseBody> logout(@Parameter(hidden = true) AuthUser authUser) {
         authUsecase.logout(authUser.id());
         return ApiResponse.success("로그아웃에 성공하였습니다.");
+    }
+
+    @Operation(summary = "토큰 재발행")
+    @PostMapping("/reissue")
+    public ResponseEntity<ResponseBody> reissue(@RequestBody @Valid ReissueRequestDto dto) {
+        TokenDto tokenDto = authUsecase.reissue(dto);
+        return ApiResponse.successWithBody("토큰 재발행에 성공하였습니다.", tokenDto);
     }
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/client/request/ReissueRequestDto.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/client/request/ReissueRequestDto.java
@@ -1,0 +1,11 @@
+package yapp.buddycon.app.auth.adapter.client.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record ReissueRequestDto(
+    @NotEmpty
+    String accessToken,
+    @NotEmpty
+    String refreshToken
+) {
+}

--- a/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
@@ -46,7 +46,7 @@ public class JwtTokenProvider implements TokenProvider {
     String storedRefreshToken = refreshTokenStorage.get(String.valueOf(user.id()));
 
     if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
-      throw new InvalidTokenException("refresh token is not found");
+      throw new InvalidTokenException("유효하지 않은 토큰입니다.");
     }
     return this.provide(user);
   }

--- a/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/jwt/JwtTokenProvider.java
@@ -3,10 +3,12 @@ package yapp.buddycon.app.auth.adapter.jwt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.adapter.jwt.exception.InvalidTokenException;
 import yapp.buddycon.app.auth.adapter.redis.RedisRefreshTokenStorage;
 import yapp.buddycon.app.auth.application.service.LocalTime;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
+import yapp.buddycon.app.common.AuthUser;
 import yapp.buddycon.app.user.domain.User;
 
 import java.time.Duration;
@@ -23,8 +25,10 @@ public class JwtTokenProvider implements TokenProvider {
 
   private final RedisRefreshTokenStorage refreshTokenStorage;
   private final JwtTokenCreator jwtTokenCreator;
+  private final JwtTokenDecryptor jwtTokenDecryptor;
   private final LocalTime time;
 
+  @Override
   public TokenDto provide(User user) {
     Instant now = time.getNow();
     Instant accessTokenExpiresIn = now.plus(Duration.ofMillis(ACCESS_TOKEN_EXPIRE_TIME));
@@ -35,6 +39,21 @@ public class JwtTokenProvider implements TokenProvider {
     refreshTokenStorage.save(String.valueOf(user.id()), tokenDto.refreshToken(), REFRESH_TOKEN_EXPIRE_TIME);
 
     return tokenDto;
+  }
+
+  @Override
+  public TokenDto reissue(User user, String refreshToken) {
+    String storedRefreshToken = refreshTokenStorage.get(String.valueOf(user.id()));
+
+    if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+      throw new InvalidTokenException("refresh token is not found");
+    }
+    return this.provide(user);
+  }
+
+  @Override
+  public AuthUser decrypt(String accessToken) {
+    return jwtTokenDecryptor.decrypt(accessToken);
   }
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/port/in/AuthUsecase.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/in/AuthUsecase.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.app.auth.application.port.in;
 
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
+import yapp.buddycon.app.auth.adapter.client.request.ReissueRequestDto;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 
 public interface AuthUsecase {
@@ -8,5 +9,7 @@ public interface AuthUsecase {
   TokenDto login(LoginRequest request);
 
   void logout(Long userId);
+
+  TokenDto reissue(ReissueRequestDto dto);
 
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/port/out/AuthToUserCommandStorage.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/out/AuthToUserCommandStorage.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.app.auth.application.port.out;
+
+import yapp.buddycon.app.user.domain.User;
+
+public interface AuthToUserCommandStorage {
+
+  User save(User user);
+
+}

--- a/src/main/java/yapp/buddycon/app/auth/application/port/out/AuthToUserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/out/AuthToUserQueryStorage.java
@@ -1,0 +1,10 @@
+package yapp.buddycon.app.auth.application.port.out;
+
+import java.util.Optional;
+import yapp.buddycon.app.user.domain.User;
+
+public interface AuthToUserQueryStorage {
+
+  Optional<User> findByClientId(Long clientId);
+  Optional<User> findById(Long id);
+}

--- a/src/main/java/yapp/buddycon/app/auth/application/port/out/TokenProvider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/port/out/TokenProvider.java
@@ -1,9 +1,12 @@
 package yapp.buddycon.app.auth.application.port.out;
 
 import yapp.buddycon.app.auth.application.service.TokenDto;
+import yapp.buddycon.app.common.AuthUser;
 import yapp.buddycon.app.user.domain.User;
 
 public interface TokenProvider {
 
     TokenDto provide(User user);
+    TokenDto reissue(User user, String refreshToken);
+    AuthUser decrypt(String accessToken);
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -7,10 +7,10 @@ import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.auth.adapter.client.request.ReissueRequestDto;
 import yapp.buddycon.app.auth.adapter.jwt.exception.InvalidTokenException;
 import yapp.buddycon.app.auth.application.port.in.AuthUsecase;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
 import yapp.buddycon.app.common.AuthUser;
-import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.user.domain.User;
 
 @Component
@@ -21,7 +21,7 @@ public class AuthService implements AuthUsecase {
     private final SignUpDecider signUpDecider;
     private final TokenProvider tokenProvider;
     private final CacheStorage cacheStorage;
-    private final UserQueryStorage userQueryStorage;
+    private final AuthToUserQueryStorage userQueryStorage;
 
     @Override
     public TokenDto login(LoginRequest request) {

--- a/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/AuthService.java
@@ -4,9 +4,13 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
+import yapp.buddycon.app.auth.adapter.client.request.ReissueRequestDto;
+import yapp.buddycon.app.auth.adapter.jwt.exception.InvalidTokenException;
 import yapp.buddycon.app.auth.application.port.in.AuthUsecase;
 import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
+import yapp.buddycon.app.common.AuthUser;
+import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.user.domain.User;
 
 @Component
@@ -17,6 +21,7 @@ public class AuthService implements AuthUsecase {
     private final SignUpDecider signUpDecider;
     private final TokenProvider tokenProvider;
     private final CacheStorage cacheStorage;
+    private final UserQueryStorage userQueryStorage;
 
     @Override
     public TokenDto login(LoginRequest request) {
@@ -28,4 +33,15 @@ public class AuthService implements AuthUsecase {
     public void logout(Long userId) {
         cacheStorage.delete(userId.toString());
     }
+
+    @Override
+    public TokenDto reissue(ReissueRequestDto dto) {
+        AuthUser authUser = tokenProvider.decrypt(dto.accessToken());
+
+        User user = userQueryStorage.findById(authUser.id())
+            .orElseThrow((() -> new InvalidTokenException("올바르지 않은 토큰입니다.")));
+
+        return tokenProvider.reissue(user, dto.refreshToken());
+    }
+
 }

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -5,18 +5,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserCommandStorage;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
 import yapp.buddycon.app.event.NotificationSettingCreationEvent;
-import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
-import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.user.domain.User;
 
 @Component
 @RequiredArgsConstructor
 public class SignUpDecider {
 
-  private final UserQueryStorage userQueryStorage;
-  private final UserCommandStorage userCommandStorage;
+  private final AuthToUserQueryStorage userQueryStorage;
+  private final AuthToUserCommandStorage userCommandStorage;
   private final OAuthUserInfoApi oAuthUserInfoApi;
   private final ApplicationEventPublisher applicationEventPublisher;
 

--- a/src/main/java/yapp/buddycon/app/user/adapter/JpaUserCommandStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/JpaUserCommandStorage.java
@@ -2,6 +2,7 @@ package yapp.buddycon.app.user.adapter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserCommandStorage;
 import yapp.buddycon.app.user.adapter.jpa.JpaUserRepository;
 import yapp.buddycon.app.user.adapter.jpa.UserMapper;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
@@ -10,7 +11,8 @@ import yapp.buddycon.app.user.domain.User;
 
 @RequiredArgsConstructor
 @Component
-public class JpaUserCommandStorage implements UserCommandStorage {
+public class JpaUserCommandStorage implements UserCommandStorage,
+    AuthToUserCommandStorage {
 
     private final JpaUserRepository jpaUserRepository;
     private final UserMapper mapper;

--- a/src/main/java/yapp/buddycon/app/user/adapter/JpaUserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/JpaUserQueryStorage.java
@@ -2,6 +2,7 @@ package yapp.buddycon.app.user.adapter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.user.adapter.jpa.JpaUserRepository;
 import yapp.buddycon.app.user.adapter.jpa.UserMapper;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
@@ -11,7 +12,8 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class JpaUserQueryStorage implements UserQueryStorage {
+public class JpaUserQueryStorage implements UserQueryStorage,
+    AuthToUserQueryStorage {
 
     private final JpaUserRepository jpaUserRepository;
     private final UserMapper mapper;

--- a/src/main/java/yapp/buddycon/app/user/adapter/JpaUserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/JpaUserQueryStorage.java
@@ -21,9 +21,13 @@ public class JpaUserQueryStorage implements UserQueryStorage {
         return jpaUserRepository.existsByClientId(clientId);
     }
 
-
     @Override
     public Optional<User> findByClientId(Long clientId) {
         return mapper.toUser(jpaUserRepository.findByClientId(clientId));
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return mapper.toUser(jpaUserRepository.findById(id));
     }
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserCommandStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserCommandStorage.java
@@ -4,5 +4,4 @@ import yapp.buddycon.app.user.domain.User;
 
 public interface UserCommandStorage {
 
-    User save(User user);
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
@@ -2,13 +2,8 @@ package yapp.buddycon.app.user.application.port.out;
 
 import yapp.buddycon.app.user.domain.User;
 
-import java.util.Optional;
-
 public interface UserQueryStorage {
 
     boolean existsByClientId(Long clientId);
 
-    Optional<User> findByClientId(Long clientId);
-
-    Optional<User> findById(Long id);
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
@@ -9,4 +9,6 @@ public interface UserQueryStorage {
     boolean existsByClientId(Long clientId);
 
     Optional<User> findByClientId(Long clientId);
+
+    Optional<User> findById(Long id);
 }

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.service.AuthService;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
@@ -17,10 +18,11 @@ import static org.mockito.Mockito.verify;
 class AuthServiceTest {
 
     @Test
-    void one_invocation_of_signup_when_login(@Mock SignUpDecider signUpDecider, @Mock TokenProvider tokenProvider, @Mock CacheStorage cacheStorage) {
+    void one_invocation_of_signup_when_login(@Mock SignUpDecider signUpDecider, @Mock TokenProvider tokenProvider,
+            @Mock CacheStorage cacheStorage, @Mock AuthToUserQueryStorage userQueryStorage) {
         // given
         var oauthAccessToken = "oauthAccessToken";
-        var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage);
+        var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage, userQueryStorage);
         var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
 
         // when

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -1,36 +1,106 @@
 package yapp.buddycon.app.auth;
 
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import yapp.buddycon.app.auth.adapter.client.request.ReissueRequestDto;
+import yapp.buddycon.app.auth.adapter.jwt.exception.InvalidTokenException;
 import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 import yapp.buddycon.app.auth.application.service.AuthService;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.auth.application.service.SignUpDecider;
 import yapp.buddycon.app.auth.application.port.out.TokenProvider;
+import yapp.buddycon.app.auth.application.service.TokenDto;
+import yapp.buddycon.app.common.AuthUser;
+import yapp.buddycon.app.user.domain.User;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
+  @InjectMocks
+  private AuthService authService;
+  @Mock
+  private SignUpDecider signUpDecider;
+  @Mock
+  private TokenProvider tokenProvider;
+  @Mock
+  private CacheStorage cacheStorage;
+  @Mock
+  private AuthToUserQueryStorage userQueryStorage;
+
+  @Test
+  void one_invocation_of_signup_when_login() {
+    // given
+    var oauthAccessToken = "oauthAccessToken";
+    var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage, userQueryStorage);
+    var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
+
+    // when
+    authService.login(request);
+
+    // then
+    verify(signUpDecider, times(1)).decide(request);
+  }
+
+  @Nested
+  class reissue {
+
     @Test
-    void one_invocation_of_signup_when_login(@Mock SignUpDecider signUpDecider, @Mock TokenProvider tokenProvider,
-            @Mock CacheStorage cacheStorage, @Mock AuthToUserQueryStorage userQueryStorage) {
-        // given
-        var oauthAccessToken = "oauthAccessToken";
-        var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage, userQueryStorage);
-        var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
+    void accessToken_decrypt가_성공하고_존재하는_유저일_경우_재발행하여_반환한다() {
+      // given
+      ReissueRequestDto dto = new ReissueRequestDto("accessToken", "refreshToken");
 
-        // when
-        authService.login(request);
+      AuthUser authUser = new AuthUser(1l);
+      when(tokenProvider.decrypt(dto.accessToken())).thenReturn(authUser);
 
-        // then
-        verify(signUpDecider, times(1)).decide(request);
+      User user = new User(1l, 123l, "", "", "", "");
+      when(userQueryStorage.findById(1l)).thenReturn(Optional.of(user));
 
+      TokenDto tokenDto = new TokenDto("new accessToken", "new refreshToken");
+      when(tokenProvider.reissue(any(), any())).thenReturn(tokenDto);
+
+      // when
+      TokenDto result = authService.reissue(dto);
+
+      // then
+      verify(tokenProvider, times(1)).reissue(user, dto.refreshToken());
+      assertThat(result.accessToken()).isEqualTo(tokenDto.accessToken());
+      assertThat(result.refreshToken()).isEqualTo(tokenDto.refreshToken());
     }
+
+    @Test
+    void accessToken_decrypt에서_반환한_유저가_storage에서_찾을_수_없는_경우_exception을_반환한다() {
+      // given
+      ReissueRequestDto dto = new ReissueRequestDto("accessToken", "refreshToken");
+
+      AuthUser authUser = new AuthUser(1l);
+      when(tokenProvider.decrypt(dto.accessToken())).thenReturn(authUser);
+
+      when(userQueryStorage.findById(1l)).thenReturn(Optional.empty());
+
+      // when
+      Throwable exception = assertThrows(InvalidTokenException.class, () -> {
+        authService.reissue(dto);
+      });
+
+      // then
+      assertThat("올바르지 않은 토큰입니다.").isEqualTo(exception.getMessage());
+      verifyNoMoreInteractions(tokenProvider);
+    }
+  }
+
 
 }

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
@@ -1,60 +1,117 @@
 package yapp.buddycon.app.auth;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenCreator;
+import yapp.buddycon.app.auth.adapter.jwt.exception.InvalidTokenException;
 import yapp.buddycon.app.auth.adapter.redis.RedisRefreshTokenStorage;
 import yapp.buddycon.app.auth.adapter.jwt.JwtTokenProvider;
 import yapp.buddycon.app.auth.application.service.LocalTime;
 import yapp.buddycon.app.auth.application.service.TokenDto;
 import yapp.buddycon.app.user.domain.User;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class JwtTokenProviderTest {
+
   @Mock
   JwtTokenCreator jwtTokenCreator;
   @Mock
   LocalTime time;
   @Mock
   RedisRefreshTokenStorage refreshTokenStorage;
+  @Spy
   @InjectMocks
   JwtTokenProvider jwtTokenProvider;
+
+  User DEFAULT_USER = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
 
   @Test
   void 토큰을_생성할때_token_creator는_한번_invocation_된다() {
     // given
-//    final var user = new User(1L, 12345678L);
-    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);
-    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
+    when(jwtTokenCreator.createToken(DEFAULT_USER, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
 
     // when
-    jwtTokenProvider.provide(user);
+    jwtTokenProvider.provide(DEFAULT_USER);
 
     // then
-    verify(jwtTokenCreator, times(1)).createToken(user, testTime, testTime, testTime);
+    verify(jwtTokenCreator, times(1)).createToken(DEFAULT_USER, testTime, testTime, testTime);
   }
 
   @Test
   void 토큰을_생성할때_refresh_token을_한번_저장한다() {
     // given
-    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
     final var testTime = new LocalTime().getNow();
 
     when(time.getNow()).thenReturn(testTime);
-    when(jwtTokenCreator.createToken(user, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
+    when(jwtTokenCreator.createToken(DEFAULT_USER, testTime, testTime, testTime)).thenReturn(new TokenDto("access", "refresh"));
 
     // when
-    jwtTokenProvider.provide(user);
+    jwtTokenProvider.provide(DEFAULT_USER);
 
     // then
     verify(refreshTokenStorage, times(1)).save(anyString(), anyString(), anyLong());
+  }
+
+  @Nested
+  class reissue {
+
+    @Test
+    void storage에서_refreshToken과_요청한_값이_다를_경우_exception을_반환한다() {
+      // given
+      when(refreshTokenStorage.get(String.valueOf(DEFAULT_USER.id()))).thenReturn("differentRefreshToken");
+
+      // when
+      Throwable exception = assertThrows(InvalidTokenException.class, () -> {
+        jwtTokenProvider.reissue(DEFAULT_USER, "refreshToken");
+      });
+
+      // then
+      assertThat("유효하지 않은 토큰입니다.").isEqualTo(exception.getMessage());
+    }
+
+    @Test
+    void storage에서_refreshToken과_요청한_값이_null일_경우_exception을_반환한다() {
+      // given
+      when(refreshTokenStorage.get(String.valueOf(DEFAULT_USER.id()))).thenReturn(null);
+
+      // when
+      Throwable exception = assertThrows(InvalidTokenException.class, () -> {
+        jwtTokenProvider.reissue(DEFAULT_USER, "refreshToken");
+      });
+
+      // then
+      assertThat("유효하지 않은 토큰입니다.").isEqualTo(exception.getMessage());
+    }
+
+    // Spy 객체 mocking 시 주의: https://stackoverflow.com/a/32944248
+    @Test
+    void storage에서_refreshToken과_요청한_값이_같을_경우_provide_메소드를_호출한다() {
+      // given
+      when(refreshTokenStorage.get(String.valueOf(DEFAULT_USER.id()))).thenReturn("refreshToken");
+
+      TokenDto expect = new TokenDto("reissue accessToken", "reissue refreshToken");
+      doReturn(expect).when(jwtTokenProvider).provide(DEFAULT_USER);
+
+      // when
+      TokenDto result = jwtTokenProvider.reissue(DEFAULT_USER, "refreshToken");
+
+      // then
+      verify(jwtTokenProvider, times(1)).provide(DEFAULT_USER);
+      assertThat(result.accessToken()).isEqualTo(expect.accessToken());
+      assertThat(result.refreshToken()).isEqualTo(expect.refreshToken());
+    }
+
   }
 }

--- a/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
@@ -12,11 +12,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserCommandStorage;
+import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
 import yapp.buddycon.app.auth.application.port.out.OAuthUserInfoApi;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.event.NotificationSettingCreationEvent;
-import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
-import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
 import yapp.buddycon.app.auth.application.service.OAuthMemberInfo;
 import yapp.buddycon.app.auth.application.service.SignUpDecider;
 import yapp.buddycon.app.user.domain.User;
@@ -25,9 +25,9 @@ import yapp.buddycon.app.user.domain.User;
 class SignUpDeciderTest {
 
   @Mock
-  UserQueryStorage userQueryStorage;
+  AuthToUserQueryStorage userQueryStorage;
   @Mock
-  UserCommandStorage userCommandStorage;
+  AuthToUserCommandStorage userCommandStorage;
   @Mock
   OAuthUserInfoApi oAuthUserInfoApi;
   @Mock


### PR DESCRIPTION
## 내용

- access token, refresh token을 이용해 토큰 재발행을 요청하는 API를 추가하였습니다.
- 추가적으로 Auth 에서 UserCommandStorage, UserQueryStorage를 직접 호출했었는데, 헥사고날에서 타 도메인의 포트를 사용하고 있는 구조라서 AuthToUserCommandStorage, AuthToUserQueryStorage를 정의하여 해당 인터페이스를 사용하도록 수정했습니다.
