### PR TITLE
[Chore] logback 설정 추가 및 환경 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### application.yml ###
-application.yml
+application*.yml

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <!-- default console appender -->
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <!-- log pattern -->
+  <property name="LOG_PATTERN" value="%d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %msg %n"/>
+
+  <!-- ACCESS_FILE Appender -->
+  <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>access-back.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <!-- 30일간 로그 보관 -->
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <!-- INFO 이상 로그만 출력 -->
+    <!-- log level : TRACE < DEBUG < INFO < WARN < ERROR -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <!-- ERROR_FILE Appender -->
+  <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>error-back.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <!-- 30일간 로그 보관 -->
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <!-- ERROR 로그만 출력 -->
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <!-- 환경별 logger -->
+  <springProfile name="local">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="dev">
+    <root level="INFO">
+      <appender-ref ref="ACCESS_FILE"/>
+      <appender-ref ref="ERROR_FILE"/>
+    </root>
+  </springProfile>
+
+</configuration>


### PR DESCRIPTION
# 내용

- application.yml 을 dev와 local로 분리하였고, gitignore에 반영했습니다. 수정된 설정 파일은 Notion에 업로드해 두었습니다~
- logback 설정 파일을 추가했습니다. local에서는 default console을 사용하고, dev는 파일에 기록하며 access-log와 error-log를 분리해서 저장합니다.