### PR TITLE
[Feature] 회원 탈퇴 API

### DIFF
--- a/src/main/java/yapp/buddycon/app/auth/adapter/AuthException.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/AuthException.java
@@ -1,0 +1,24 @@
+package yapp.buddycon.app.auth.adapter;
+
+import lombok.Getter;
+import yapp.buddycon.app.common.response.BadRequestException;
+
+public class AuthException extends BadRequestException {
+
+  @Getter
+  public enum AuthExceptionCode {
+    DELETED_USER("탈퇴된 회원입니다."),
+    ;
+
+    private String message;
+
+    AuthExceptionCode(String message) {
+      this.message = message;
+    }
+  }
+
+  public AuthException(AuthExceptionCode code) {
+    super(code.message);
+  }
+
+}

--- a/src/main/java/yapp/buddycon/app/auth/adapter/redis/RedisRefreshTokenStorage.java
+++ b/src/main/java/yapp/buddycon/app/auth/adapter/redis/RedisRefreshTokenStorage.java
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Component;
 import yapp.buddycon.app.auth.application.port.out.CacheStorage;
 
 import java.util.concurrent.TimeUnit;
+import yapp.buddycon.app.user.application.port.out.UserToAuthCommandStorage;
 
 @RequiredArgsConstructor
 @Component
-public class RedisRefreshTokenStorage implements CacheStorage<String, String> {
+public class RedisRefreshTokenStorage implements CacheStorage<String, String>,
+    UserToAuthCommandStorage<String, String> {
 
   private final RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -33,7 +33,7 @@ public class SignUpDecider {
     // 존재하지 않는 유저라면 생성
     User createdUser = userCommandStorage.save(
         new User(null, clientId, request.nickname(), request.email(), request.gender(),
-            request.age()));
+            request.age(), false));
 
     applicationEventPublisher.publishEvent(new NotificationSettingCreationEvent(createdUser.id()));
     return createdUser;

--- a/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
+++ b/src/main/java/yapp/buddycon/app/auth/application/service/SignUpDecider.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import yapp.buddycon.app.auth.adapter.AuthException;
+import yapp.buddycon.app.auth.adapter.AuthException.AuthExceptionCode;
 import yapp.buddycon.app.auth.adapter.client.LoginRequest;
 import yapp.buddycon.app.auth.application.port.out.AuthToUserCommandStorage;
 import yapp.buddycon.app.auth.application.port.out.AuthToUserQueryStorage;
@@ -27,7 +29,13 @@ public class SignUpDecider {
     // 존재하는 유저라면 그대로 반환
     Optional<User> existingUser = userQueryStorage.findByClientId(clientId);
     if (existingUser.isPresent()) {
-      return existingUser.get();
+      User user = existingUser.get();
+
+      // 탈퇴한 유저
+      if (user.deleted()) {
+        throw new AuthException(AuthExceptionCode.DELETED_USER);
+      }
+      return user;
     }
 
     // 존재하지 않는 유저라면 생성

--- a/src/main/java/yapp/buddycon/app/user/UserException.java
+++ b/src/main/java/yapp/buddycon/app/user/UserException.java
@@ -1,0 +1,23 @@
+package yapp.buddycon.app.user;
+
+import lombok.Getter;
+import yapp.buddycon.app.common.response.BadRequestException;
+
+public class UserException extends BadRequestException {
+
+  @Getter
+  public enum UserExceptionCode {
+    USER_NOT_FOUND("유저를 찾을 수 없습니다"),
+    ;
+
+    private String message;
+
+    UserExceptionCode(String message) {
+      this.message = message;
+    }
+  }
+
+  public UserException(UserExceptionCode code) {
+    super(code.message);
+  }
+}

--- a/src/main/java/yapp/buddycon/app/user/adapter/client/DeleteUserController.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/client/DeleteUserController.java
@@ -1,0 +1,32 @@
+package yapp.buddycon.app.user.adapter.client;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.app.common.AuthUser;
+import yapp.buddycon.app.common.response.ApiResponse;
+import yapp.buddycon.app.common.response.ResponseBody;
+import yapp.buddycon.app.user.application.port.in.DeleteUserUsecase;
+
+@Tag(name = "유저 삭제", description = "유저 삭제 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class DeleteUserController {
+
+  private final DeleteUserUsecase usecase;
+
+  @Operation(summary = "자체 회원탈퇴")
+  @DeleteMapping("/me")
+  public ResponseEntity<ResponseBody<Void>> deleteUser(
+      @Parameter(hidden = true) AuthUser user) {
+    usecase.delete(user.id());
+    return ApiResponse.success("회원 탈퇴 처리 되었습니다.");
+  }
+
+}

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserEntity.java
@@ -2,15 +2,15 @@ package yapp.buddycon.app.user.adapter.jpa;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 import yapp.buddycon.app.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
+@Where(clause = "deleted = false")
 @Table(name = "users")
 public class UserEntity extends BaseEntity {
 
@@ -31,4 +31,17 @@ public class UserEntity extends BaseEntity {
     private String gender;
 
     private String age;
+
+    private boolean deleted;
+
+    public UserEntity(Long id, Long clientId, String nickname, String email, String gender,
+        String age, boolean deleted) {
+        this.id = id;
+        this.clientId = clientId;
+        this.nickname = nickname;
+        this.email = email;
+        this.gender = gender;
+        this.age = age;
+        this.deleted = deleted;
+    }
 }

--- a/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserMapper.java
+++ b/src/main/java/yapp/buddycon/app/user/adapter/jpa/UserMapper.java
@@ -9,14 +9,14 @@ import java.util.Optional;
 public class UserMapper {
 
     public User toUser(UserEntity entity) {
-        return new User(entity.getId(), entity.getClientId(), entity.getNickname(), entity.getEmail(), entity.getGender(), entity.getAge());
+        return new User(entity.getId(), entity.getClientId(), entity.getNickname(), entity.getEmail(), entity.getGender(), entity.getAge(), entity.isDeleted());
     }
 
     public Optional<User> toUser(Optional<UserEntity> entity) {
-        return entity.map(userEntity -> new User(userEntity.getId(), userEntity.getClientId(), userEntity.getNickname(), userEntity.getEmail(), userEntity.getGender(), userEntity.getAge()));
+        return entity.map(userEntity -> new User(userEntity.getId(), userEntity.getClientId(), userEntity.getNickname(), userEntity.getEmail(), userEntity.getGender(), userEntity.getAge(), userEntity.isDeleted()));
     }
 
     public UserEntity toEntity(User user) {
-        return new UserEntity(user.id(), user.clientId(), user.nickname(), user.email(), user.gender(), user.age());
+        return new UserEntity(user.id(), user.clientId(), user.nickname(), user.email(), user.gender(), user.age(), user.deleted());
     }
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/in/DeleteUserUsecase.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/in/DeleteUserUsecase.java
@@ -1,0 +1,6 @@
+package yapp.buddycon.app.user.application.port.in;
+
+public interface DeleteUserUsecase {
+
+  void delete(Long userId);
+}

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserCommandStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserCommandStorage.java
@@ -4,4 +4,6 @@ import yapp.buddycon.app.user.domain.User;
 
 public interface UserCommandStorage {
 
+  User save(User user);
+
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserQueryStorage.java
@@ -1,9 +1,11 @@
 package yapp.buddycon.app.user.application.port.out;
 
+import java.util.Optional;
 import yapp.buddycon.app.user.domain.User;
 
 public interface UserQueryStorage {
 
     boolean existsByClientId(Long clientId);
+    Optional<User> findById(Long userId);
 
 }

--- a/src/main/java/yapp/buddycon/app/user/application/port/out/UserToAuthCommandStorage.java
+++ b/src/main/java/yapp/buddycon/app/user/application/port/out/UserToAuthCommandStorage.java
@@ -1,0 +1,6 @@
+package yapp.buddycon.app.user.application.port.out;
+
+public interface UserToAuthCommandStorage<K, V> {
+
+  void delete(K key);
+}

--- a/src/main/java/yapp/buddycon/app/user/application/service/DeleteUserService.java
+++ b/src/main/java/yapp/buddycon/app/user/application/service/DeleteUserService.java
@@ -8,6 +8,7 @@ import yapp.buddycon.app.user.UserException.UserExceptionCode;
 import yapp.buddycon.app.user.application.port.in.DeleteUserUsecase;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
+import yapp.buddycon.app.user.application.port.out.UserToAuthCommandStorage;
 import yapp.buddycon.app.user.domain.User;
 
 @Service
@@ -17,16 +18,18 @@ public class DeleteUserService implements DeleteUserUsecase {
 
   private final UserQueryStorage userQueryStorage;
   private final UserCommandStorage userCommandStorage;
+  private final UserToAuthCommandStorage userToAuthCommandStorage;
 
   @Override
   public void delete(Long userId) {
     User user = userQueryStorage.findById(userId).orElseThrow(() ->
         new UserException(UserExceptionCode.USER_NOT_FOUND));
 
+    // jwt 로그아웃
+    userToAuthCommandStorage.delete(userId.toString());
+
+    // 유저 삭제 처리
     User deletedUser = user.delete();
-
-    // todo jwt 로그아웃 처리
-
     userCommandStorage.save(deletedUser);
   }
 }

--- a/src/main/java/yapp/buddycon/app/user/application/service/DeleteUserService.java
+++ b/src/main/java/yapp/buddycon/app/user/application/service/DeleteUserService.java
@@ -1,0 +1,32 @@
+package yapp.buddycon.app.user.application.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yapp.buddycon.app.user.UserException;
+import yapp.buddycon.app.user.UserException.UserExceptionCode;
+import yapp.buddycon.app.user.application.port.in.DeleteUserUsecase;
+import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
+import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
+import yapp.buddycon.app.user.domain.User;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserService implements DeleteUserUsecase {
+
+  private final UserQueryStorage userQueryStorage;
+  private final UserCommandStorage userCommandStorage;
+
+  @Override
+  public void delete(Long userId) {
+    User user = userQueryStorage.findById(userId).orElseThrow(() ->
+        new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+    User deletedUser = user.delete();
+
+    // todo jwt 로그아웃 처리
+
+    userCommandStorage.save(deletedUser);
+  }
+}

--- a/src/main/java/yapp/buddycon/app/user/domain/User.java
+++ b/src/main/java/yapp/buddycon/app/user/domain/User.java
@@ -6,7 +6,8 @@ public record User(
   String nickname,
   String email,
   String gender,
-  String age
+  String age,
+  boolean deleted
 ) {
 
 }

--- a/src/main/java/yapp/buddycon/app/user/domain/User.java
+++ b/src/main/java/yapp/buddycon/app/user/domain/User.java
@@ -10,4 +10,8 @@ public record User(
   boolean deleted
 ) {
 
+  // delete method
+  public User delete() {
+    return new User(id, clientId, nickname, email, gender, age, true);
+  }
 }

--- a/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/AuthServiceTest.java
@@ -44,7 +44,7 @@ class AuthServiceTest {
     var oauthAccessToken = "oauthAccessToken";
     var authService = new AuthService(signUpDecider, tokenProvider, cacheStorage, userQueryStorage);
     var request = new LoginRequest(oauthAccessToken, "nickname", "email", "FEMALE", "10-20");
-    var user = new User(1l, 123l, "", "", "", "");
+    var user = new User(1l, 123l, "", "", "", "", false);
     when(signUpDecider.decide(request)).thenReturn(user);
 
     // when
@@ -65,7 +65,7 @@ class AuthServiceTest {
       AuthUser authUser = new AuthUser(1l);
       when(tokenProvider.decrypt(dto.accessToken())).thenReturn(authUser);
 
-      User user = new User(1l, 123l, "", "", "", "");
+      User user = new User(1l, 123l, "", "", "", "", false);
       when(userQueryStorage.findById(1l)).thenReturn(Optional.of(user));
 
       TokenDto tokenDto = new TokenDto("new accessToken", "new refreshToken", 1l, false);

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenCreatorTest.java
@@ -30,7 +30,7 @@ class JwtTokenCreatorTest {
 
     // given
     final var jwtTokenCreator = new JwtTokenCreator(jwtTokenSecretKey);
-    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
+    final var user = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20", false);
     final var testTime = new LocalTime().getNow();
     final var secretKey = "abcdefghijklmnopqrstuvwxyz12345678901234567890abcdefghijklmnopqrstuvwxyz12345678901234567890";
 

--- a/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/JwtTokenProviderTest.java
@@ -32,7 +32,7 @@ class JwtTokenProviderTest {
   @InjectMocks
   JwtTokenProvider jwtTokenProvider;
 
-  User DEFAULT_USER = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20");
+  User DEFAULT_USER = new User(1L, 12345678L, "nickname", "email", "FEMALE", "10-20", false);
 
   @Test
   void 토큰을_생성할때_token_creator는_한번_invocation_된다() {

--- a/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
@@ -41,6 +41,7 @@ class SignUpDeciderTest {
     var validAccessToken = "oauthAccessToken";
     var memberInfo = new OAuthMemberInfo(1L);
     var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
+    when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
     when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.empty());
     User savedUser = new User(1l, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age());
     when(userCommandStorage.save(any())).thenReturn(savedUser);
@@ -59,6 +60,7 @@ class SignUpDeciderTest {
     var validAccessToken = "oauthAccessToken";
     var memberInfo = new OAuthMemberInfo(1L);
     var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
+    when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
     when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.of(new User(1L, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age())));
 
     // when

--- a/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
+++ b/src/test/java/yapp/buddycon/app/auth/SignUpDeciderTest.java
@@ -43,14 +43,14 @@ class SignUpDeciderTest {
     var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
     when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
     when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.empty());
-    User savedUser = new User(1l, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age());
+    User savedUser = new User(1l, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age(), false);
     when(userCommandStorage.save(any())).thenReturn(savedUser);
 
     // when
     signUpDecider.decide(request);
 
     // then
-    verify(userCommandStorage).save(new User(null, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age()));
+    verify(userCommandStorage).save(new User(null, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age(), false));
     verify(applicationEventPublisher).publishEvent(new NotificationSettingCreationEvent(1l));
   }
 
@@ -61,7 +61,7 @@ class SignUpDeciderTest {
     var memberInfo = new OAuthMemberInfo(1L);
     var request = new LoginRequest(validAccessToken, "nickname", "email", "FEMALE", "10-20");
     when(oAuthUserInfoApi.call(validAccessToken)).thenReturn(memberInfo);
-    when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.of(new User(1L, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age())));
+    when(userQueryStorage.findByClientId(memberInfo.id())).thenReturn(Optional.of(new User(1L, memberInfo.id(), request.nickname(), request.email(), request.gender(), request.age(), false)));
 
     // when
     signUpDecider.decide(request);

--- a/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/gifticon/GifticonJpaRepositoryTest.java
@@ -36,7 +36,7 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용한_기프티콘_목록만_반환() {
       // given
-      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false);
       userRepository.save(user);
       GifticonEntity 사용하지_않은_기프티콘1 = createGifticonEntity("사용하지 않은 기프티콘 1", false, GifticonStore.STARBUCKS, user.getId());
       GifticonEntity 사용하지_않은_기프티콘2 = createGifticonEntity("사용하지 않은 기프티콘 2", false, GifticonStore.STARBUCKS, user.getId());
@@ -55,11 +55,11 @@ public class GifticonJpaRepositoryTest {
 
     @Test
     void 유저_필터링() {
-      UserEntity user = new UserEntity(null, 111L, "nickname1", "dd1@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 111L, "nickname1", "dd1@domain.com", "male", "20", false);
       user = userRepository.save(user);
       GifticonEntity 사용한_기프티콘1 = createGifticonEntity("사용한 기프티콘 1", true, GifticonStore.STARBUCKS, user.getId());
 
-      UserEntity user2 = new UserEntity(null, 222L, "nickname2", "dd2@domain.com", "male", "20");
+      UserEntity user2 = new UserEntity(null, 222L, "nickname2", "dd2@domain.com", "male", "20", false);
       user2 = userRepository.save(user2);
       GifticonEntity 사용한_기프티콘2 = createGifticonEntity("사용한 기프티콘 2", true, GifticonStore.STARBUCKS, user2.getId());
 
@@ -79,7 +79,7 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 사용_이전의_기프티콘_목록_조회() {
       // given
-      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false);
       user = userRepository.save(user);
       createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user.getId());
       createGifticonEntity("name2", false, GifticonStore.CU, user.getId());
@@ -96,7 +96,7 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 이름_순서로_정렬_목록_조회() {
       // given
-      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false);
       user = userRepository.save(user);
       createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user.getId());
       GifticonEntity 조회대상_기프티콘 = createGifticonEntity("name1", false, GifticonStore.CU, user.getId());
@@ -118,7 +118,7 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 카테고리_필터링_지정_목록_조회() {
       // given
-      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false);
       user = userRepository.save(user);
       createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user.getId());
       createGifticonEntity("name2", false, GifticonStore.CU, user.getId());
@@ -138,7 +138,7 @@ public class GifticonJpaRepositoryTest {
     @Test
     void 정상조회() {
       // given
-      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20");
+      UserEntity user = new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false);
       user = userRepository.save(user);
       GifticonEntity target = createGifticonEntity("name1", false, GifticonStore.STARBUCKS, user.getId());
 
@@ -168,9 +168,9 @@ public class GifticonJpaRepositoryTest {
     void 유저_아이디로만_필터링() {
       // given
       UserEntity user1 = userRepository.save(
-              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20"));
+              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false));
       UserEntity user2 = userRepository.save(
-              new UserEntity(null, 456L, "nickname2", "dd2@domain.com", "male", "20"));
+              new UserEntity(null, 456L, "nickname2", "dd2@domain.com", "male", "20", false));
 
       createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user1.getId());
       createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user1.getId());
@@ -189,9 +189,9 @@ public class GifticonJpaRepositoryTest {
     void 유저_아이디와_사용여부와_카테고리로_필터링() {
       // given
       UserEntity user1 = userRepository.save(
-              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20"));
+              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false));
       UserEntity user2 = userRepository.save(
-              new UserEntity(null, 456L, "nickname2", "dd2@domain.com", "male", "20"));
+              new UserEntity(null, 456L, "nickname2", "dd2@domain.com", "male", "20", false));
 
       createGifticonEntity("name5", false, GifticonStore.STARBUCKS, user1.getId());
       createGifticonEntity("name5", false, GifticonStore.MACDONALD, user1.getId());
@@ -212,7 +212,7 @@ public class GifticonJpaRepositoryTest {
     void 남은_만료_일자로_필터링() {
       // given
       UserEntity user = userRepository.save(
-              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20"));
+              new UserEntity(null, 123L, "nickname", "dd@domain.com", "male", "20", false));
 
       gifticonJpaRepository.save(GifticonEntity.builder() // 조회 대상
               .userId(user.getId()).imageUrl("url1").name("name").used(true).gifticonStore(GifticonStore.CU)

--- a/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
+++ b/src/test/java/yapp/buddycon/app/notification/NotificationJpaRepositoryTest.java
@@ -57,8 +57,8 @@ public class NotificationJpaRepositoryTest {
 
     @BeforeEach
     void dataInit() {
-      사용자1 = userRepository.save(new UserEntity(null, 123L, "nickname1", "aa@domain.com", "male", "20"));
-      사용자2 = userRepository.save(new UserEntity(null, 456L, "nickname2", "bb@domain.com", "female", "20"));
+      사용자1 = userRepository.save(new UserEntity(null, 123L, "nickname1", "aa@domain.com", "male", "20", false));
+      사용자2 = userRepository.save(new UserEntity(null, 456L, "nickname2", "bb@domain.com", "female", "20", false));
     }
 
     @Test

--- a/src/test/java/yapp/buddycon/app/user/DeleteUserServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/user/DeleteUserServiceTest.java
@@ -1,0 +1,47 @@
+package yapp.buddycon.app.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
+import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
+import yapp.buddycon.app.user.application.service.DeleteUserService;
+import yapp.buddycon.app.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteUserServiceTest {
+
+  @Mock
+  UserQueryStorage userQueryStorage;
+  @Mock
+  UserCommandStorage userCommandStorage;
+  @InjectMocks
+  DeleteUserService service;
+
+  @Test
+  void 유저_삭제시_삭제된_유저를_저장한다() {
+    // given
+    final long userId = 1L;
+    User user = new User(userId, 123l, "", "", "", "", false);
+
+    when(userQueryStorage.findById(userId)).thenReturn(Optional.of(user));
+
+    // when
+    service.delete(userId);
+
+    // then
+    ArgumentCaptor<User> savedUser = ArgumentCaptor.forClass(User.class);
+
+    verify(userCommandStorage).save(savedUser.capture());
+    assertEquals(savedUser.getValue().id(), userId);
+    assertEquals(savedUser.getValue().deleted(), true);
+  }
+}

--- a/src/test/java/yapp/buddycon/app/user/DeleteUserServiceTest.java
+++ b/src/test/java/yapp/buddycon/app/user/DeleteUserServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yapp.buddycon.app.user.application.port.out.UserCommandStorage;
 import yapp.buddycon.app.user.application.port.out.UserQueryStorage;
+import yapp.buddycon.app.user.application.port.out.UserToAuthCommandStorage;
 import yapp.buddycon.app.user.application.service.DeleteUserService;
 import yapp.buddycon.app.user.domain.User;
 
@@ -23,6 +24,8 @@ public class DeleteUserServiceTest {
   UserQueryStorage userQueryStorage;
   @Mock
   UserCommandStorage userCommandStorage;
+  @Mock
+  UserToAuthCommandStorage userToAuthCommandStorage;
   @InjectMocks
   DeleteUserService service;
 
@@ -43,5 +46,20 @@ public class DeleteUserServiceTest {
     verify(userCommandStorage).save(savedUser.capture());
     assertEquals(savedUser.getValue().id(), userId);
     assertEquals(savedUser.getValue().deleted(), true);
+  }
+
+  @Test
+  void 유저_삭제_시_JWT_토큰을_로그아웃_처리한다() {
+
+    // given
+    final long userId = 1L;
+    User user = new User(userId, 123l, "", "", "", "", false);
+    when(userQueryStorage.findById(userId)).thenReturn(Optional.of(user));
+
+    // when
+    service.delete(userId);
+
+    // then
+    verify(userToAuthCommandStorage).delete("1");
   }
 }


### PR DESCRIPTION
## 개요

회원탈퇴 API를 추가하고 관련 로직을 수정하였습니다.

## 세부 내용

- 회원탈퇴 API 추가: `DELETE::/api/v1/users/me`
  - 회원탈퇴 시 JWT 로그아웃 처리
  - 유저 soft delete 처리
- User 테이블에 deleted 필드 추가
- 로그인 시 탈퇴한 유저인지 확인 후 예외처리